### PR TITLE
Fix python3 syntax error

### DIFF
--- a/src/pytest_benchmark/pep418.py
+++ b/src/pytest_benchmark/pep418.py
@@ -44,7 +44,7 @@ try:
     import ctypes
     import ctypes.util
     from ctypes import byref, POINTER
-except ImportError, err:
+except ImportError as err:
     pass
 else:
     def ctypes_oserror():


### PR DESCRIPTION
Python 3 does not permit the usage of commas for binding exceptions to local variables in `except` blocks.