### PR TITLE
add more info to machine_info

### DIFF
--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -1000,13 +1000,21 @@ def pytest_terminal_summary(terminalreporter):
 
 
 def pytest_benchmark_generate_machine_info():
+    python_implementation = platform.python_implementation()
+    python_implementation_version = platform.python_version()
+    if python_implementation == 'PyPy':
+        python_implementation_version = '%d.%d.%d' % sys.pypy_version_info[:3]
+        if sys.pypy_version_info.releaselevel != 'final':
+            python_implementation_version += '-%s%d' % sys.pypy_version_info[3:]
     return {
         "node": platform.node(),
         "processor": platform.processor(),
         "machine": platform.machine(),
         "python_compiler": platform.python_compiler(),
-        "python_implementation": platform.python_implementation(),
+        "python_implementation": python_implementation,
+        "python_implementation_version": python_implementation_version,
         "python_version": platform.python_version(),
+        "python_build": platform.python_build(),
         "release": platform.release(),
         "system": platform.system()
     }


### PR DESCRIPTION
in particular, add the pypy version when on pypy, and the revision of the build, useful when comparing benchmarks against multiple versions of not-released-yet pypys :)