### PR TITLE
Fix histogram with latest PyGal version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Authors
 * Thomas Waldmann - https://github.com/ThomasWaldmann
 * Antonio Cuni - http://antocuni.eu/en/
 * Petr Šebek - https://github.com/Artimi
+* Swen Kooij - https://github.com/Photonios

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
   particular the exact model. Contributed by Antonio Cuni in `#61 <https://github.com/ionelmc/pytest-benchmark/pull/61>`_.
 * Added ``benchmark.extra_info``, which you can use to save arbitrary stuff in
   the JSON. Contributed by Antonio Cuni in the same PR as above.
+* Fix histograms with latest PyGal version.
 
 
 3.1.0a1 (2016-10-29)

--- a/src/pytest_benchmark/histogram.py
+++ b/src/pytest_benchmark/histogram.py
@@ -2,10 +2,10 @@ import py
 
 from .utils import TIME_UNITS
 from .utils import slugify
+from .utils import is_list_like
 
 try:
     from pygal.graph.box import Box
-    from pygal.graph.graph import is_list_like
     from pygal.style import DefaultStyle
 except ImportError as exc:
     raise ImportError(exc.args, "Please install pygal and pygaljs or pytest-benchmark[histogram]")

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 import types
+from collections import Iterable
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
@@ -578,3 +579,8 @@ def get_cprofile_functions(stats):
                            function_name=function_name))
 
     return result
+
+
+def is_list_like(value):
+    """Return whether value is an iterable but not a mapping / string"""
+    return isinstance(value, Iterable) and not isinstance(value, (base, dict))


### PR DESCRIPTION
PyGal made a change:

https://github.com/Kozea/pygal/commit/c7aefc39898dcc48f595b4bed372eebc1f28629e

This caused is_list_like to no longer be imported in pygal.graph.box.
pytest-benchmark should _not_ import this method from pygal. It comes
from their _compat module, which is considered private.