### PR TITLE
Hide creds when saving and use netrc file 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Authors
 * Petr Šebek - https://github.com/Artimi
 * Swen Kooij - https://github.com/Photonios
 * Vara Canero - https://github.com/varac
+* Andre Bianchi - https://github.com/drebs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 
 * Added a ``time`` field in ``commit_info``. Contributed by Vara Canero in
   `#71 <https://github.com/ionelmc/pytest-benchmark/pull/71>`_.
+* Fixed the leaking of credentials by masking the URL printed when storing
+  data to elasticsearch.
+* Added a `--benchmark-netrc` option to use credentials from a netrc file when
+  storing data to elasticsearch.
 
 3.1.0a2 (2017-03-27)
 --------------------

--- a/src/pytest_benchmark/cli.py
+++ b/src/pytest_benchmark/cli.py
@@ -147,7 +147,7 @@ def main():
     parser = make_parser()
     args = parser.parse_args()
     logger = Logger(args.verbose)
-    storage = load_storage(args.storage, logger=logger)
+    storage = load_storage(args.storage, logger=logger, netrc=args.netrc)
 
     if args.command == 'list':
         for file in storage.query():

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -111,8 +111,8 @@ def add_global_options(addoption, prefix="benchmark-"):
     )
     addoption(
         "--{0}netrc".format(prefix),
-        action="store_true", default=False,
-        help="Load elasticsearch credentials from ~/.netrc file.",
+        nargs="?", default='', const='~/.netrc',
+        help="Load elasticsearch credentials from a netrc file. Default: %(default)r.",
     )
     addoption(
         "--{0}verbose".format(prefix), *[] if prefix else ['-v'],

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -110,6 +110,11 @@ def add_global_options(addoption, prefix="benchmark-"):
              "are converted to file://<value>. Default: %(default)r."
     )
     addoption(
+        "--{0}netrc".format(prefix),
+        action="store_true", default=False,
+        help="Load elasticsearch credentials from ~/.netrc file.",
+    )
+    addoption(
         "--{0}verbose".format(prefix), *[] if prefix else ['-v'],
         action="store_true", default=False,
         help="Dump diagnostic and progress information."

--- a/src/pytest_benchmark/session.py
+++ b/src/pytest_benchmark/session.py
@@ -36,7 +36,8 @@ class BenchmarkSession(object):
         self.storage = load_storage(
             config.getoption("benchmark_storage"),
             logger=self.logger,
-            default_machine_id=self.machine_id
+            default_machine_id=self.machine_id,
+            netrc=config.getoption("benchmark_netrc")
         )
         self.options = dict(
             min_time=SecondsDecimal(config.getoption("benchmark_min_time")),

--- a/src/pytest_benchmark/storage/elasticsearch.py
+++ b/src/pytest_benchmark/storage/elasticsearch.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
+import re
 import sys
 import uuid
 from datetime import date
 from datetime import datetime
 from decimal import Decimal
+from functools import partial
 
 from ..compat import reraise
 
@@ -162,8 +164,12 @@ class ElasticsearchStorage(object):
                 body=bench,
                 id=doc_id,
             )
+        # hide user's credentials before logging
+        m = re.compile('^([^:]+)://[^@]+@')
+        sub_fun = partial(m.sub, '\\1://***:***@')
+        masked_hosts = list(map(sub_fun, self._es_hosts))
         self.logger.info("Saved benchmark data to %s to index %s as doctype %s" % (
-            self._es_hosts, self._es_index, self._es_doctype))
+            masked_hosts, self._es_index, self._es_doctype))
 
     def _create_index(self):
         mapping = {

--- a/src/pytest_benchmark/storage/elasticsearch.py
+++ b/src/pytest_benchmark/storage/elasticsearch.py
@@ -30,6 +30,13 @@ class BenchmarkJSONSerializer(JSONSerializer):
             return "UNSERIALIZABLE[%r]" % data
 
 
+def _mask_hosts(hosts):
+    m = re.compile('^([^:]+)://[^@]+@')
+    sub_fun = partial(m.sub, '\\1://***:***@')
+    masked_hosts = list(map(sub_fun, hosts))
+    return masked_hosts
+
+
 class ElasticsearchStorage(object):
     def __init__(self, hosts, index, doctype, project_name, logger,
                  default_machine_id=None):
@@ -165,9 +172,7 @@ class ElasticsearchStorage(object):
                 id=doc_id,
             )
         # hide user's credentials before logging
-        m = re.compile('^([^:]+)://[^@]+@')
-        sub_fun = partial(m.sub, '\\1://***:***@')
-        masked_hosts = list(map(sub_fun, self._es_hosts))
+        masked_hosts = _mask_hosts(self._es_hosts)
         self.logger.info("Saved benchmark data to %s to index %s as doctype %s" % (
             masked_hosts, self._es_index, self._es_doctype))
 

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -405,12 +405,12 @@ def parse_save(string):
     return string
 
 
-def _parse_hosts(storage_url, use_netrc):
+def _parse_hosts(storage_url, netrc_file):
 
     # load creds from netrc file
-    path = os.path.expanduser('~/.netrc')
+    path = os.path.expanduser(netrc_file)
     creds = None
-    if use_netrc and os.path.isfile(path):
+    if netrc_file and os.path.isfile(path):
         creds = netrc.netrc(path)
 
     # add creds to urls
@@ -430,9 +430,9 @@ def _parse_hosts(storage_url, use_netrc):
 
 
 def parse_elasticsearch_storage(string, default_index="benchmark",
-                                default_doctype="benchmark", use_netrc=False):
+                                default_doctype="benchmark", netrc_file=''):
     storage_url = urlparse(string)
-    hosts = _parse_hosts(storage_url, use_netrc)
+    hosts = _parse_hosts(storage_url, netrc_file)
     index = default_index
     doctype = default_doctype
     if storage_url.path and storage_url.path != "/":
@@ -451,7 +451,7 @@ def parse_elasticsearch_storage(string, default_index="benchmark",
 def load_storage(storage, **kwargs):
     if "://" not in storage:
         storage = "file://" + storage
-    use_netrc = kwargs.pop('netrc', False)  # only used by elasticsearch storage
+    netrc_file = kwargs.pop('netrc')  # only used by elasticsearch storage
     if storage.startswith("file://"):
         from .storage.file import FileStorage
         return FileStorage(storage[len("file://"):], **kwargs)
@@ -459,7 +459,7 @@ def load_storage(storage, **kwargs):
         from .storage.elasticsearch import ElasticsearchStorage
         # TODO update benchmark_autosave
         args = parse_elasticsearch_storage(storage[len("elasticsearch+"):],
-                                           use_netrc=use_netrc)
+                                           netrc_file=netrc_file)
         return ElasticsearchStorage(*args, **kwargs)
     else:
         raise argparse.ArgumentTypeError("Storage must be in form of file://path or "


### PR DESCRIPTION
This is related to #72.

When using `--benchmark-storage` with elasticsearch feature pytest-benchmark prints the whole URL when saving the data after tests finished. If the URL contains credentials and if the results of the run are public, then the credentials are leaked. The first commit in this pull request addresses this issue by masking eventual credentials before printing the URL.

Note that this does not protect other leaks such as when using tox together with pytest, as tox will print the whole pytest command line before running it and leak credentials anyway. Our current workaround for this is to use CI environment variables to set the content of a `pytest.ini` file with the relevant options for pytest. Those options are not printed by tox because they are loaded by pytest itself.

The second commit of this pull request implements the use of the `~/.netrc` file by adding the `--benchmark-netrc` option. Further work can be done to add a `--benchmark-netrc-file` (using the same semantics as `curl`) to point to a specific file other than the default one in user's home directory.