### PR TITLE
Fix update hooks specs

### DIFF
--- a/src/pytest_benchmark/hookspec.py
+++ b/src/pytest_benchmark/hookspec.py
@@ -10,7 +10,7 @@ def pytest_benchmark_generate_machine_info(config):
     pass
 
 
-def pytest_benchmark_update_machine_info(config, info):
+def pytest_benchmark_update_machine_info(config, machine_info):
     """
     If benchmarks are compared and machine_info is different then warnings will be shown.
 
@@ -18,8 +18,8 @@ def pytest_benchmark_update_machine_info(config, info):
 
     .. sourcecode:: python
 
-        def pytest_benchmark_update_machine_info(config, info):
-            info['user'] = getpass.getuser()
+        def pytest_benchmark_update_machine_info(config, machine_info):
+            machine_info['user'] = getpass.getuser()
     """
     pass
 

--- a/src/pytest_benchmark/hookspec.py
+++ b/src/pytest_benchmark/hookspec.py
@@ -36,14 +36,14 @@ def pytest_benchmark_generate_commit_info(config):
     pass
 
 
-def pytest_benchmark_update_commit_info(config, info):
+def pytest_benchmark_update_commit_info(config, commit_info):
     """
     To add something into the commit_info, like the commit message do something like this:
 
     .. sourcecode:: python
 
-        def pytest_benchmark_update_commit_info(config, info):
-            info['message'] = subprocess.check_output(['git', 'log', '-1', '--pretty=%B']).strip()
+        def pytest_benchmark_update_commit_info(config, commit_info):
+            commit_info['message'] = subprocess.check_output(['git', 'log', '-1', '--pretty=%B']).strip()
     """
     pass
 

--- a/src/pytest_benchmark/hookspec.py
+++ b/src/pytest_benchmark/hookspec.py
@@ -4,7 +4,7 @@ def pytest_benchmark_generate_machine_info(config):
 
     .. sourcecode:: python
 
-        def pytest_benchmark_update_machine_info(config):
+        def pytest_benchmark_generate_machine_info(config):
             return {'user': getpass.getuser()}
     """
     pass


### PR DESCRIPTION
The hook calls and the specs used different parameter names for `pytest_benchmark_update_machine_info` and `pytest_benchmark_update_commit_info`, and pytest complained and failed when trying to override those hooks.

These commits fix the specs by changing the parameters names. Another approach would be to maintain the specs and change the hook calls, but it made more sense to change the parameter names in specs to maintain coherence with other hooks and with the parts of the code that call these hooks.

This pull request is made on top of https://github.com/ionelmc/pytest-benchmark/pull/73, so that one should be merged first.