### PR TITLE
Ignore FileNotFoundError when guessing project name.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Authors
 * Swen Kooij - https://github.com/Photonios
 * "varac" - https://github.com/varac
 * Andre Bianchi - https://github.com/drebs
+* Jeremy Dobbins-Bucklad - https://github.com/jad-b

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
   storing data to elasticsearch. Both contributed by Andre Bianchi in
   `#73 <https://github.com/ionelmc/pytest-benchmark/pull/73>`_.
 * Fixed docs on hooks. Contributed by Andre Bianchi in `#74 <https://github.com/ionelmc/pytest-benchmark/pull/74>`_.
+* Remove `git` and `hg` as system dependencies when guessing the project name.
 
 3.1.0a2 (2017-03-27)
 --------------------

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -119,7 +119,7 @@ class Fallback(object):
         return self
 
 
-get_project_name = Fallback(IndexError, CalledProcessError, FileNotFoundError)
+get_project_name = Fallback(IndexError, CalledProcessError, OSError)
 
 
 @get_project_name.register

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -119,7 +119,7 @@ class Fallback(object):
         return self
 
 
-get_project_name = Fallback(IndexError, CalledProcessError)
+get_project_name = Fallback(IndexError, CalledProcessError, FileNotFoundError)
 
 
 @get_project_name.register


### PR DESCRIPTION
If the host system (or container) is missing programs like 'git' or 'hg', a FileNotFoundError is raised, which crashes the process. This patch adds this error to the list of continuable exceptions.

The tox tests pass against python3.5 & 2.7; waiting on Travis to verify the rest.
```bash
  py35: commands succeeded
  py27: commands succeeded
  congratulations :)
```