### PR TITLE
Support simple trial x-axis histogram label

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,4 +15,4 @@ Authors
 * Jeremy Dobbins-Bucklad - https://github.com/jad-b
 * Alexey Popravka - https://github.com/popravich
 * Ken Crowell - https://github.com/oeuftete
-* Matthew Feickert - https://github.com/matthewfeickert 
+* Matthew Feickert - https://github.com/matthewfeickert

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
   (see `#110 <https://github.com/ionelmc/pytest-benchmark/pull/110>`_).
 * Fix misspelled unit (see
   `#97 <https://github.com/ionelmc/pytest-benchmark/issues/97>`_).
+* Support simple ``trial`` x-axis histogram label (see
+  `#95 <https://github.com/ionelmc/pytest-benchmark/issues/95>`_).
 
 3.1.1 (2017-07-26)
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -163,7 +163,7 @@ Commandline options
                         outliers, rounds, iterations'
   --benchmark-name=FORMAT
                         How to format names in results. Can be one of 'short',
-                        'normal', 'long'. Default: 'normal'
+                        'normal', 'long', or 'trial'. Default: 'normal'
   --benchmark-histogram=FILENAME-PREFIX
                         Plot graphs of min/max/avg/stddev over time in
                         FILENAME-PREFIX-test_name.svg. If FILENAME-PREFIX
@@ -202,7 +202,7 @@ The compare ``command`` takes almost all the ``--benchmark`` options, minus the 
                             table. Default: 'min, max, mean, stddev, median, iqr,
                             outliers, rounds, iterations'
       --name=FORMAT         How to format names in results. Can be one of 'short',
-                            'normal', 'long'. Default: 'normal'
+                            'normal', 'long', or 'trial'. Default: 'normal'
       --histogram=FILENAME-PREFIX
                             Plot graphs of min/max/avg/stddev over time in
                             FILENAME-PREFIX-test_name.svg. If FILENAME-PREFIX

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -76,7 +76,7 @@ def add_display_options(addoption, prefix="benchmark-"):
         "--{0}name".format(prefix),
         metavar="FORMAT", type=parse_name_format,
         default="normal",
-        help="How to format names in results. Can be one of 'short', 'normal', 'long'. Default: %(default)r"
+        help="How to format names in results. Can be one of 'short', 'normal', 'long', or 'trial'. Default: %(default)r"
     )
 
 

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -332,10 +332,18 @@ def name_formatter_long(bench):
         return bench["fullname"]
 
 
+def name_formatter_trial(bench):
+    if bench["source"]:
+        return "%.4s" % split(bench["source"])[-1]
+    else:
+        return '????'
+
+
 NAME_FORMATTERS = {
     "short": name_formatter_short,
     "normal": name_formatter_normal,
     "long": name_formatter_long,
+    "trial": name_formatter_trial,
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,7 +104,7 @@ def test_help_compare(testdir, args):
         "                        table. Default: 'min, max, mean, stddev, median, iqr,",
         "                        outliers, rounds, iterations'",
         "  --name FORMAT         How to format names in results. Can be one of 'short',",
-        "                        'normal', 'long'. Default: 'normal'",
+        "                        'normal', 'long', or 'trial'. Default: 'normal'",
         "  --histogram [FILENAME-PREFIX]",
         "                        Plot graphs of min/max/avg/stddev over time in",
         "                        FILENAME-PREFIX-test_name.svg. If FILENAME-PREFIX",
@@ -171,8 +171,13 @@ def test_list(testdir):
     assert result.ret == 0
 
 
-@pytest.mark.parametrize('name', ['short', 'long', 'normal'])
-def test_compare(testdir, name):
+@pytest.mark.parametrize('name,name_pattern_generator', [
+    ('short', lambda n: '*xfast_parametrized[[]0[]] ' '(%.4d*)' % n),
+    ('long', lambda n: '*xfast_parametrized[[]0[]] ' '(%.4d*)' % n),
+    ('normal', lambda n: '*xfast_parametrized[[]0[]] ' '(%.4d*)' % n),
+    ('trial', lambda n: '%.4d*' % n)
+])
+def test_compare(testdir, name, name_pattern_generator):
     result = testdir.run('py.test-benchmark', '--storage', STORAGE, 'compare', '0001', '0002', '0003',
                          '--sort', 'min',
                          '--columns', 'min,max',
@@ -192,11 +197,11 @@ def test_compare(testdir, name):
     result.stdout.fnmatch_lines([
         'Computing stats ...',
         '---*--- benchmark: 3 tests ---*---',
-        'Name (time in ns) *                   Min    *    Max          ',
+        'Name (time in ns) * Min * Max          ',
         '---*---',
-        '*xfast_parametrized[[]0[]] (0003*)     215.6286 (1.0)      10*318.6159 (1.33)   ',
-        '*xfast_parametrized[[]0[]] (0002*)     216.9028 (1.01)      7*739.2997 (1.0)    ',
-        '*xfast_parametrized[[]0[]] (0001*)     217.3145 (1.01)     11*447.3891 (1.48)   ',
+        '%s * 215.6286 (1.0)      10*318.6159 (1.33)   ' % name_pattern_generator(3),
+        '%s * 216.9028 (1.01)      7*739.2997 (1.0)    ' % name_pattern_generator(2),
+        '%s * 217.3145 (1.01)     11*447.3891 (1.48)   ' % name_pattern_generator(1),
         '---*---',
         '',
         'Legend:',

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -135,7 +135,7 @@ def force_bytes(text):
         return text
 
 
-@pytest.fixture(params=['short', 'normal', 'long'])
+@pytest.fixture(params=['short', 'normal', 'long', 'trial'])
 def name_format(request):
     return request.param
 
@@ -210,6 +210,12 @@ def test_regression_checks(sess, name_format):
             ('tests/test_normal.py::test_xfast_parametrized[0] (0001_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190343_uncommitted-changes)',
              "Field 'max' has failed DifferenceRegressionCheck: 0.000001843 > 0.000001000")
         ],
+        'trial': [
+            ('0001',
+             "Field 'stddev' has failed PercentageRegressionCheck: 23.331641765 > 5.000000000"),
+            ('0001',
+             "Field 'max' has failed DifferenceRegressionCheck: 0.000001843 > 0.000001000")
+        ],
     }[name_format]
     output = make_logger(sess)
     pytest.raises(PerformanceRegression, sess.check_regressions)
@@ -226,6 +232,10 @@ def test_regression_checks(sess, name_format):
         'long': """Performance has regressed:
 \ttests/test_normal.py::test_xfast_parametrized[0] (0001_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190343_uncommitted-changes) - Field 'stddev' has failed PercentageRegressionCheck: 23.331641765 > 5.000000000
 \ttests/test_normal.py::test_xfast_parametrized[0] (0001_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190343_uncommitted-changes) - Field 'max' has failed DifferenceRegressionCheck: 0.000001843 > 0.000001000
+""",
+        'trial': """Performance has regressed:
+\t0001 - Field 'stddev' has failed PercentageRegressionCheck: 23.331641765 > 5.000000000
+\t0001 - Field 'max' has failed DifferenceRegressionCheck: 0.000001843 > 0.000001000
 """
     }[name_format]
 
@@ -270,6 +280,12 @@ def test_regression_checks_inf(sess, name_format):
              '(0002_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190348_uncommitted-changes)',
              "Field 'max' has failed DifferenceRegressionCheck: 0.000005551 > "
              '0.000001000')
+        ],
+        'trial': [
+            ('0002',
+             "Field 'stddev' has failed PercentageRegressionCheck: inf > 5.000000000"),
+            ('0002',
+             "Field 'max' has failed DifferenceRegressionCheck: 0.000005551 > 0.000001000")
         ]
     }[name_format]
     output = make_logger(sess)
@@ -287,6 +303,10 @@ def test_regression_checks_inf(sess, name_format):
         'long': """Performance has regressed:
 \ttests/test_normal.py::test_xfast_parametrized[0] (0002_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190348_uncommitted-changes) - Field 'stddev' has failed PercentageRegressionCheck: inf > 5.000000000
 \ttests/test_normal.py::test_xfast_parametrized[0] (0002_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190348_uncommitted-changes) - Field 'max' has failed DifferenceRegressionCheck: 0.000005551 > 0.000001000
+""",
+        'trial': """Performance has regressed:
+\t0002 - Field 'stddev' has failed PercentageRegressionCheck: inf > 5.000000000
+\t0002 - Field 'max' has failed DifferenceRegressionCheck: 0.000005551 > 0.000001000
 """
     }[name_format]
 
@@ -308,10 +328,10 @@ def test_compare_1(sess, LineMatcher):
         '-changes.json',
         '',
         '*------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------*',
-        'Name (time in ns)               *      Min                 *Max                Mean              StdDev              Median                IQR            Outliers  Rounds  Iterations  OPS (Mops/s) *',
+        'Name (time in ns) * Min                 * Max                Mean              StdDev              Median                IQR            Outliers  Rounds  Iterations  OPS (Mops/s) *',
         '-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*',
-        '*xfast_parametrized[[]0[]] (0001*)     217.3145 (1.0)      11*447.3891 (1.0)      262.2408 (1.00)     214.0442 (1.0)      220.1664 (1.00)     38.2154 (2.03)      90;1878    9987         418        3.8133 (1.00)*',
-        '*xfast_parametrized[[]0[]] (NOW) *     217.9511 (1.00)     13*290.0380 (1.16)     261.2051 (1.0)      263.9842 (1.23)     220.1638 (1.0)      18.8080 (1.0)      160;1726    9710         431        3.8284 (1.0)*',
+        '*0001* 217.3145 (1.0)      11*447.3891 (1.0)      262.2408 (1.00)     214.0442 (1.0)      220.1664 (1.00)     38.2154 (2.03)      90;1878    9987         418        3.8133 (1.00)*',
+        '*NOW*  217.9511 (1.00)     13*290.0380 (1.16)     261.2051 (1.0)      263.9842 (1.23)     220.1638 (1.0)      18.8080 (1.0)      160;1726    9710         431        3.8284 (1.0)*',
         '--------------------------------------------------------------------------------------------------------------------------------------------------------------------*',
         'Legend:',
         '  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.',
@@ -337,10 +357,10 @@ def test_compare_2(sess, LineMatcher):
         'Comparing against benchmarks from: 0002_b87b9aae14ff14a7887a6bbaa9731b9a8760555d_20150814_190348_uncommitted-changes.json',
         '',
         '*------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------*',
-        'Name (time in ns)            *         Min                 *Max                Mean              StdDev              Median                IQR            Outliers  Rounds  Iterations  OPS (Mops/s)*',
+        'Name (time in ns) * Min                 *Max                Mean              StdDev              Median                IQR            Outliers  Rounds  Iterations  OPS (Mops/s)*',
         '--------------------------------------------------------------------------------------------------------------------------------------------------------------------*',
-        '*xfast_parametrized[[]0[]] (0002*)     216.9028 (1.0)       7*739.2997 (1.0)      254.0585 (1.0)        0.0000 (1.0)      219.8103 (1.0)      27.3309 (1.45)     235;1688   11009         410        3.9361 (1.0)*',
-        '*xfast_parametrized[[]0[]] (NOW) *     217.9511 (1.00)     13*290.0380 (1.72)     261.2051 (1.03)     263.9842 (inf)      220.1638 (1.00)     18.8080 (1.0)      160;1726    9710         431        3.8284 (0.97)*',
+        '*0002* 216.9028 (1.0)       7*739.2997 (1.0)      254.0585 (1.0)        0.0000 (1.0)      219.8103 (1.0)      27.3309 (1.45)     235;1688   11009         410        3.9361 (1.0)*',
+        '*NOW*  217.9511 (1.00)     13*290.0380 (1.72)     261.2051 (1.03)     263.9842 (inf)      220.1638 (1.00)     18.8080 (1.0)      160;1726    9710         431        3.8284 (0.97)*',
         '--------------------------------------------------------------------------------------------------------------------------------------------------------------------*',
         'Legend:',
         '  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.',


### PR DESCRIPTION
Support simple trial x-axis histogram label, adding `trial` to the `--name` option.  Without this, there appears to be no way to generate histograms for long test names without having the x-axis labels take up a large amount of available real estate.

TODO:

* [x] fix tests, maybe (problems locally, anyway)