### PR TITLE
[cprofile] fix number of functions shown

### DIFF
--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -229,7 +229,7 @@ def pytest_addoption(parser):
         "--benchmark-cprofile",
         metavar="COLUMN", default=None,
         choices=['ncalls_recursion', 'ncalls', 'tottime', 'tottime_per', 'cumtime', 'cumtime_per', 'function_name'],
-        help="If specified measure one run with cProfile and stores 10 top functions."
+        help="If specified measure one run with cProfile and stores 25 top functions."
              " Argument is a column to sort by. Available columns: 'ncallls_recursion',"
              " 'ncalls', 'tottime', 'tottime_per', 'cumtime', 'cumtime_per', 'function_name'."
     )

--- a/src/pytest_benchmark/stats.py
+++ b/src/pytest_benchmark/stats.py
@@ -229,7 +229,7 @@ class Metadata(object):
                 stats_columns.insert(0, cprofile)
             for column in stats_columns:
                 cprofile_functions.sort(key=operator.itemgetter(column), reverse=True)
-                for cprofile_function in cprofile_functions[:25]:
+                for cprofile_function in cprofile_functions[:10]:
                     if cprofile_function not in cprofile_list:
                         cprofile_list.append(cprofile_function)
                 # if we want only one column or we already have all available functions

--- a/src/pytest_benchmark/stats.py
+++ b/src/pytest_benchmark/stats.py
@@ -229,7 +229,7 @@ class Metadata(object):
                 stats_columns.insert(0, cprofile)
             for column in stats_columns:
                 cprofile_functions.sort(key=operator.itemgetter(column), reverse=True)
-                for cprofile_function in cprofile_functions[:10]:
+                for cprofile_function in cprofile_functions[:25]:
                     if cprofile_function not in cprofile_list:
                         cprofile_list.append(cprofile_function)
                 # if we want only one column or we already have all available functions


### PR DESCRIPTION
It should only be 10, based on https://github.com/ionelmc/pytest-benchmark/blob/ca13fbff602bf1cf169a035a900e8f765a587044/src/pytest_benchmark/plugin.py#L232.

cc @ionelmc 