### PR TITLE
Add note in docs on passing --benchmark-histogram option last

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Authors
 * Jeremy Dobbins-Bucklad - https://github.com/jad-b
 * Alexey Popravka - https://github.com/popravich
 * Ken Crowell - https://github.com/oeuftete
+* Matthew Feickert - https://github.com/matthewfeickert 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 3.1.2-dev
 ---------
 
+* Add note to docs on placement of ``--benchmark-histogram`` option
+  (see `#110 <https://github.com/ionelmc/pytest-benchmark/pull/110>` _).
 * Fix misspelled unit (see
   `#97 <https://github.com/ionelmc/pytest-benchmark/issues/97>`_).
 

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -38,7 +38,7 @@ Plotting
     To use plotting you need to ``pip install pygal pygaljs`` or ``pip install pytest-benchmark[histogram]``.
 
 
-You can also get a nice plot with ``--benchmark-histogram``. The result is a modified Tukey box and wiskers plot where the
+You can also get a nice plot with ``--benchmark-histogram``. The result is a modified Tukey box and whisker plot where the
 outliers (the small bullets) are ``Min`` and ``Max``. Note that if you do not supply a name for the plot it is recommended
 that ``--benchmark-histogram`` is the last option passed.
 

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -39,7 +39,8 @@ Plotting
 
 
 You can also get a nice plot with ``--benchmark-histogram``. The result is a modified Tukey box and wiskers plot where the
-outliers (the small bullets) are ``Min`` and ``Max``.
+outliers (the small bullets) are ``Min`` and ``Max``. Note that if you do not supply a name for the plot it is recommended
+that ``--benchmark-histogram`` is the last option passed.
 
 Example output:
 


### PR DESCRIPTION
Following the discussion in Issue #102, it might be helpful to explicitly mention in the docs that for the default naming scheme to work that you should pass the `--benchmark-histogram` option last.

Checklist from [`CONTRIBUTING.md`](https://github.com/ionelmc/pytest-benchmark/blob/master/CONTRIBUTING.rst#pull-request-guidelines):
- [ ] Include passing tests (run `tox`)
- [x] ~~Update documentation when there's new API, functionality etc.~~
- [x] Add a note to `CHANGELOG.rst` about the changes.
- [x] Add yourself to `AUTHORS.rst`