### PR TITLE
Suppress warning on enabled xdist on or missing statistics dependency if the user had already asked --benchmark_disable

### DIFF
--- a/src/pytest_benchmark/session.py
+++ b/src/pytest_benchmark/session.py
@@ -53,7 +53,7 @@ class BenchmarkSession(object):
         self.disabled = config.getoption("benchmark_disable") and not config.getoption("benchmark_enable")
         self.cprofile_sort_by = config.getoption("benchmark_cprofile")
 
-        if config.getoption("dist", "no") != "no" and not self.skip:
+        if config.getoption("dist", "no") != "no" and not self.skip and not self.disabled:
             self.logger.warn(
                 "BENCHMARK-U2",
                 "Benchmarks are automatically disabled because xdist plugin is active."
@@ -63,7 +63,7 @@ class BenchmarkSession(object):
             self.disabled = True
         if hasattr(config, "slaveinput"):
             self.disabled = True
-        if not statistics:
+        if not statistics and not self.disabled:
             self.logger.warn(
                 "BENCHMARK-U3",
                 "Benchmarks are automatically disabled because we could not import `statistics`\n\n%s" %


### PR DESCRIPTION
Hello,
very minor change that I noticed while looking at logs of a testuite of one of my projects. If pytest-benchmark is already disabled there should be no need of warning the user about that.

Best regards,
Francesco