### PR TITLE
Use the pathlib2 when it's available

### DIFF
--- a/ci/templates/tox.ini
+++ b/ci/templates/tox.ini
@@ -30,7 +30,7 @@ deps =
     pytest-instafail==0.3.0
     xdist: pytest-xdist==1.20.1
     {py27,pypy}: statistics==1.0.3.5
-    {py27,pypy}: pathlib==1.0.1
+    {py27,pypy}: pathlib2==2.3.2
     {py27,pypy}: mock==2.0.0
     pytest28: pytest==2.8.7
     pytest29: pytest==2.9.2

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     extras_require={
         'aspect': ['aspectlib'],
         'histogram': ['pygal', 'pygaljs'],
-        ':python_version < "3.4"': ['statistics', 'pathlib'],
+        ':python_version < "3.4"': ['statistics', 'pathlib2'],
         'elasticsearch': ['elasticsearch']
     },
     entry_points={

--- a/src/pytest_benchmark/storage/file.py
+++ b/src/pytest_benchmark/storage/file.py
@@ -1,11 +1,11 @@
 import json
 import os
-from pathlib import Path
 
 from ..stats import normalize_stats
 from ..utils import commonpath
 from ..utils import safe_dumps
 from ..utils import short_filename
+from ..utils import Path
 
 
 class FileStorage(object):

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -23,6 +23,13 @@ from os.path import split
 
 from .compat import PY3
 
+# This is here (in the utils module) because it might be used by
+# various other modules.
+try:
+    from pathlib2 import Path   # noqa: F401
+except ImportError:
+    from pathlib import Path    # noqa: F401
+
 try:
     from urllib.parse import urlparse, parse_qs
 except ImportError:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,6 @@ import os
 import sys
 from io import BytesIO
 from io import StringIO
-from pathlib import Path
 
 import py
 import pytest
@@ -22,6 +21,7 @@ from pytest_benchmark.utils import NAME_FORMATTERS
 from pytest_benchmark.utils import DifferenceRegressionCheck
 from pytest_benchmark.utils import PercentageRegressionCheck
 from pytest_benchmark.utils import get_machine_id
+from pytest_benchmark.utils import Path
 
 pytest_plugins = "pytester"
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     pytest-instafail==0.3.0
     xdist: pytest-xdist==1.20.1
     {py27,pypy}: statistics==1.0.3.5
-    {py27,pypy}: pathlib==1.0.1
+    {py27,pypy}: pathlib2==2.3.2
     {py27,pypy}: mock==2.0.0
     pytest28: pytest==2.8.7
     pytest29: pytest==2.9.2


### PR DESCRIPTION
Now that pathlib is receiving improvements and changes in general, the
backward compatibility layer called `pathlib' was deprecated in favor
of a module with different name that can be installed in
parallel (pathlib2). This change favors importing pathlib2 since
that's most likely only installed in systems that actually require
that to function.