### PR TITLE
Update --columns help (missing ops)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -160,7 +160,7 @@ Commandline options
   --benchmark-columns=LABELS
                         Comma-separated list of columns to show in the result
                         table. Default: 'min, max, mean, stddev, median, iqr,
-                        outliers, rounds, iterations'
+                        outliers, ops, rounds, iterations'
   --benchmark-name=FORMAT
                         How to format names in results. Can be one of 'short',
                         'normal', 'long'. Default: 'normal'

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -70,7 +70,7 @@ def add_display_options(addoption, prefix="benchmark-"):
         metavar="LABELS", type=parse_columns,
         default=["min", "max", "mean", "stddev", "median", "iqr", "outliers", "ops", "rounds", "iterations"],
         help="Comma-separated list of columns to show in the result table. Default: "
-             "'min, max, mean, stddev, median, iqr, outliers, rounds, iterations'"
+             "'min, max, mean, stddev, median, iqr, outliers, ops, rounds, iterations'"
     )
     addoption(
         "--{0}name".format(prefix),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -88,7 +88,7 @@ def test_help(testdir):
         "  --benchmark-columns=LABELS",
         "                        Comma-separated list of columns to show in the result",
         "                        table. Default: 'min, max, mean, stddev, median, iqr,",
-        "                        outliers, rounds, iterations'",
+        "                        outliers, ops, rounds, iterations'",
         "  --benchmark-histogram=[FILENAME-PREFIX]",
         "                        Plot graphs of min/max/avg/stddev over time in",
         "                        FILENAME-PREFIX-test_name.svg. If FILENAME-PREFIX",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,7 +102,7 @@ def test_help_compare(testdir, args):
         "                        @pytest.parametrize. Default: 'group'",
         "  --columns LABELS      Comma-separated list of columns to show in the result",
         "                        table. Default: 'min, max, mean, stddev, median, iqr,",
-        "                        outliers, rounds, iterations'",
+        "                        outliers, ops, rounds, iterations'",
         "  --name FORMAT         How to format names in results. Can be one of 'short',",
         "                        'normal', 'long'. Default: 'normal'",
         "  --histogram [FILENAME-PREFIX]",


### PR DESCRIPTION
Small fix for the help message, the `ops` column was missing from the list of default columns.