### PR TITLE
allow pytest to default to skip

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -109,7 +109,7 @@ Commandline options
   --benchmark-enable    Forcibly enable benchmarks. Use this option to
                         override --benchmark-disable (in case you have it in
                         pytest configuration).
-  --benchmark-only      Only run benchmarks.
+  --benchmark-only      Only run benchmarks. This overrides --benchmark-skip.
   --benchmark-save=NAME
                         Save the current run into 'STORAGE-PATH/counter-
                         NAME.json'. Default: '<commitid>_<date>_<time>_<isdirty>', example:

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -188,7 +188,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--benchmark-only",
         action="store_true", default=False,
-        help="Only run benchmarks."
+        help="Only run benchmarks. This overrides --benchmark-skip."
     )
     group.addoption(
         "--benchmark-save",

--- a/src/pytest_benchmark/session.py
+++ b/src/pytest_benchmark/session.py
@@ -76,7 +76,7 @@ class BenchmarkSession(object):
         self.sort = config.getoption("benchmark_sort")
         self.columns = config.getoption("benchmark_columns")
         if self.skip and self.only:
-            raise pytest.UsageError("Can't have both --benchmark-only and --benchmark-skip options.")
+            self.skip = False
         if self.disabled and self.only:
             raise pytest.UsageError(
                 "Can't have both --benchmark-only and --benchmark-disable options. Note that --benchmark-disable is "

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -42,7 +42,7 @@ def test_help(testdir):
         "  --benchmark-disable-gc",
         "                        Disable GC during benchmarks.",
         "  --benchmark-skip      Skip running any tests that contain benchmarks.",
-        "  --benchmark-only      Only run benchmarks.",
+        "  --benchmark-only      Only run benchmarks. This overrides --benchmark-skip.",
         "  --benchmark-save=NAME",
         "                        Save the current run into 'STORAGE-",
         "                        PATH/counter_NAME.json'.",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -66,7 +66,7 @@ def test_help(testdir):
         "                        Can be used multiple times.",
         "  --benchmark-cprofile=COLUMN",
         "                        If specified measure one run with cProfile and stores",
-        "                        10 top functions. Argument is a column to sort by.",
+        "                        25 top functions. Argument is a column to sort by.",
         "                        Available columns: 'ncallls_recursion', 'ncalls',",
         "                        'tottime', 'tottime_per', 'cumtime', 'cumtime_per',",
         "                        'function_name'.",

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -438,11 +438,19 @@ def test_b(benchmark):
     ])
 
 
-def test_conflict_between_only_and_skip(testdir):
+def test_only_override_skip(testdir):
     test = testdir.makepyfile(SIMPLE_TEST)
     result = testdir.runpytest('--benchmark-only', '--benchmark-skip', test)
     result.stderr.fnmatch_lines([
-        "ERROR: Can't have both --benchmark-only and --benchmark-skip options."
+        "*collected 2 items",
+        "test_only_override_skip.py ..*",
+        "* benchmark: 2 tests *",
+        "Name (time in ?s) * Min * Max * Mean * StdDev * Rounds * Iterations",
+        "------*",
+        "test_fast          *",
+        "test_slow          *",
+        "------*",
+        "*====== 2 passed* seconds ======*",
     ])
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -441,7 +441,7 @@ def test_b(benchmark):
 def test_only_override_skip(testdir):
     test = testdir.makepyfile(SIMPLE_TEST)
     result = testdir.runpytest('--benchmark-only', '--benchmark-skip', test)
-    result.stderr.fnmatch_lines([
+    result.stdout.fnmatch_lines([
         "*collected 2 items",
         "test_only_override_skip.py ..*",
         "* benchmark: 2 tests *",


### PR DESCRIPTION
@ionelmc Hello again!

This allows:

```
# tox.ini
[pytest]
addopts = --benchmark-skip
```

and one would only need to put `--benchmark-only` for the small subset of invocations/envs where you actually want to benchmark, eliminating `--benchmark-skip` everywhere else.