### PR TITLE
Require pytest>=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pytest', 'benchmark',
     ],
     install_requires=[
-        'pytest>=2.8',
+        'pytest>=3.6',
         'py-cpuinfo',
     ],
     extras_require={


### PR DESCRIPTION
Changes introduced by pytest 4.0 are breaking ones and require at least 3.6. Ref #129

Thanks, @ionelmc!