### PR TITLE
Fix flake8 warnings

### DIFF
--- a/ci/appveyor-bootstrap.py
+++ b/ci/appveyor-bootstrap.py
@@ -16,7 +16,7 @@ except ImportError:
 
 BASE_URL = "https://www.python.org/ftp/python/"
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
-GET_PIP_PATH = "C:\get-pip.py"
+GET_PIP_PATH = r"C:\get-pip.py"
 URLS = {
     ("2.7", "64"): BASE_URL + "2.7.10/python-2.7.13.amd64.msi",
     ("2.7", "32"): BASE_URL + "2.7.10/python-2.7.13.msi",

--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -110,7 +110,7 @@ class Fallback(object):
         for func in self.functions:
             try:
                 value = func(*args, **kwargs)
-            except self.exceptions as exc:
+            except self.exceptions:
                 continue
             else:
                 if value:
@@ -282,9 +282,9 @@ class DifferenceRegressionCheck(RegressionCheck):
 
 
 def parse_compare_fail(string,
-                       rex=re.compile('^(?P<field>min|max|mean|median|stddev|iqr):'
-                                      '((?P<percentage>[0-9]?[0-9])%|(?P<difference>[0-9]*\.?[0-9]+([eE][-+]?['
-                                      '0-9]+)?))$')):
+                       rex=re.compile(r'^(?P<field>min|max|mean|median|stddev|iqr):'
+                                      r'((?P<percentage>[0-9]?[0-9])%|(?P<difference>[0-9]*\.?[0-9]+([eE][-+]?['
+                                      r'0-9]+)?))$')):
     m = rex.match(string)
     if m:
         g = m.groupdict()
@@ -580,7 +580,7 @@ def report_noprogress(iterable, *args, **kwargs):
 
 
 def slugify(name):
-    for c in "\/:*?<>| ":
+    for c in r"\/:*?<>| ":
         name = name.replace(c, '_').replace('__', '_')
     return name
 


### PR DESCRIPTION
``flake8>=3.6.0`` produces following warnings on current master and it makes some ``pytest-benchmark`` ci tasks to fail:
```
$ flake8 src/ tests/ setup.py
src/pytest_benchmark/utils.py:113:39: F841 local variable 'exc' is assigned to but never used
src/pytest_benchmark/utils.py:285:45: W605 invalid escape sequence '\.'
src/pytest_benchmark/utils.py:583:6: W605 invalid escape sequence '\/'
```