### PR TITLE
Fix DeprecationWarning about 'U' open mode

### DIFF
--- a/src/pytest_benchmark/compat.py
+++ b/src/pytest_benchmark/compat.py
@@ -4,6 +4,7 @@ PY3 = sys.version_info[0] == 3
 
 XRANGE = range if PY3 else xrange  # flake8: noqa
 INT = (int,) if PY3 else (int, long)  # flake8: noqa
+OPEN_MODE = "r" if PY3 else "rU"  # flake8: noqa
 
 if PY3:
     import builtins

--- a/src/pytest_benchmark/storage/file.py
+++ b/src/pytest_benchmark/storage/file.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 
+from ..compat import OPEN_MODE
 from ..stats import normalize_stats
 from ..utils import commonpath
 from ..utils import safe_dumps
@@ -100,7 +101,7 @@ class FileStorage(object):
             if file in self._cache:
                 data = self._cache[file]
             else:
-                with file.open("rU") as fh:
+                with file.open(OPEN_MODE) as fh:
                     try:
                         data = json.load(fh)
                         for bench in data["benchmarks"]:

--- a/tests/test_elasticsearch_storage.py
+++ b/tests/test_elasticsearch_storage.py
@@ -12,6 +12,7 @@ import pytest
 from freezegun import freeze_time
 
 from pytest_benchmark import plugin
+from pytest_benchmark.compat import OPEN_MODE
 from pytest_benchmark.plugin import BenchmarkSession
 from pytest_benchmark.plugin import pytest_benchmark_compare_machine_info
 from pytest_benchmark.plugin import pytest_benchmark_generate_json
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 THIS = py.path.local(__file__)
 BENCHFILE = THIS.dirpath('test_storage/0030_5b78858eb718649a31fb93d8dc96ca2cee41a4cd_20150815_030419_uncommitted-changes.json')
-SAVE_DATA = json.load(BENCHFILE.open('rU'))
+SAVE_DATA = json.load(BENCHFILE.open(OPEN_MODE))
 SAVE_DATA["machine_info"] = {'foo': 'bar'}
 SAVE_DATA["commit_info"] = {'foo': 'bar'}
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,7 @@ import pytest
 from freezegun import freeze_time
 
 from pytest_benchmark import plugin
+from pytest_benchmark.compat import OPEN_MODE
 from pytest_benchmark.plugin import BenchmarkSession
 from pytest_benchmark.plugin import pytest_benchmark_compare_machine_info
 from pytest_benchmark.plugin import pytest_benchmark_generate_json
@@ -391,7 +392,7 @@ def test_save_with_name(sess, tmpdir, monkeypatch):
     files = list(Path(str(tmpdir)).rglob('*.json'))
     print(files)
     assert len(files) == 1
-    assert json.load(files[0].open('rU')) == JSON_DATA
+    assert json.load(files[0].open(OPEN_MODE)) == JSON_DATA
 
 
 @freeze_time("2015-08-15T00:04:18.687119")
@@ -405,7 +406,7 @@ def test_save_no_name(sess, tmpdir, monkeypatch):
     sess.handle_saving()
     files = list(Path(str(tmpdir)).rglob('*.json'))
     assert len(files) == 1
-    assert json.load(files[0].open('rU')) == JSON_DATA
+    assert json.load(files[0].open(OPEN_MODE)) == JSON_DATA
 
 
 @freeze_time("2015-08-15T00:04:18.687119")
@@ -421,7 +422,7 @@ def test_save_with_error(sess, tmpdir, monkeypatch):
     sess.handle_saving()
     files = list(Path(str(tmpdir)).rglob('*.json'))
     assert len(files) == 1
-    assert json.load(files[0].open('rU')) == {
+    assert json.load(files[0].open(OPEN_MODE)) == {
         'benchmarks': [],
         'commit_info': {'foo': 'bar'},
         'datetime': '2015-08-15T00:04:18.687119',
@@ -441,4 +442,4 @@ def test_autosave(sess, tmpdir, monkeypatch):
     sess.handle_saving()
     files = list(Path(str(tmpdir)).rglob('*.json'))
     assert len(files) == 1
-    assert json.load(files[0].open('rU')) == JSON_DATA
+    assert json.load(files[0].open(OPEN_MODE)) == JSON_DATA


### PR DESCRIPTION
According to https://docs.python.org/3.3/library/functions.html#open :
"'U' universal newlines mode (for backwards compatibility; should not
be used in new code)"
To control how universal newlines works there is "newline" option.
So, to fix it is enough to remove "U" from a set of open options.

Fixes: https://github.com/ionelmc/pytest-benchmark/issues/137