### PR TITLE
add PYTEST_DONT_REWRITE in order to suppress already imported warning

### DIFF
--- a/src/pytest_benchmark/__init__.py
+++ b/src/pytest_benchmark/__init__.py
@@ -1,1 +1,3 @@
+"""pytest: avoid already-imported warning: PYTEST_DONT_REWRITE."""
+
 __version__ = '3.2.2'


### PR DESCRIPTION
After calling pytest.main twice, pytest creates this `warning summary `

```bash
===================================================================== warnings summary =====================================================================
~/lib/python2.7/site-packages/_pytest/assertion/rewrite.py:272
~/lib/python2.7/site-packages/_pytest/assertion/rewrite.py:272: PytestWarning: Module already imported so cannot be rewritten: pytest_benchmark
    self.config,
...
```
According to 
 * https://github.com/pytest-dev/pytest/issues/2995
 * https://github.com/pytest-dev/pytest-cov/pull/228/commits/22387a604ce8a082cc6381f1bbc28fa434c97bbe

the doc string `PYTEST_DONT_REWRITE` can be used to suppress this warning.