### PR TITLE
Add benchmark `baseline` option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Authors
 * Stanislav Levin - https://github.com/stanislavlevin
 * Grygorii Iermolenko - https://github.com/gyermolenko
 * Jonathan Simon Prates - https://github.com/jonathansp
+* Alexander Schlarb – https://ninetailed.ninja/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Future
+------
+
+* Add ``baseline`` boolean option to benchmark options to allow adding benchmarks
+  for comparision that do not affect relative scores.
+
 3.2.3 (2020-01-10)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -240,6 +240,7 @@ You can set per-test options with the ``benchmark`` marker:
 
     @pytest.mark.benchmark(
         group="group-name",
+        baseline=True,
         min_time=0.1,
         max_time=0.5,
         min_rounds=5,
@@ -258,6 +259,20 @@ You can set per-test options with the ``benchmark`` marker:
         # Note: this code is not measured.
         assert result is None
 
+Additionally to the options whose name coincides with the relevant
+command-line options, this allows modifying the following values:
+
+``group``
+    A user-defined group name that this benchmark belongs to. Use this
+    to group related benchmarks for comparing values in the results
+    printed by pytest.
+
+``baseline``
+    Whether this benchmark's results should be considered as possible
+    base line values when comparing them to other results of the same
+    group? Use this if you want to include some results just for
+    comparison, without them affecting the relative scores displayed
+    for other results.
 
 Extra info
 ==========

--- a/src/pytest_benchmark/fixture.py
+++ b/src/pytest_benchmark/fixture.py
@@ -33,8 +33,9 @@ class BenchmarkFixture(object):
     _precisions = {}
 
     def __init__(self, node, disable_gc, timer, min_rounds, min_time, max_time, warmup, warmup_iterations,
-                 calibration_precision, add_stats, logger, warner, disabled, cprofile, group=None):
+                 calibration_precision, add_stats, logger, warner, disabled, cprofile, group=None, baseline=True):
         self.name = node.name
+        self.baseline = baseline
         self.fullname = node._nodeid
         self.disabled = disabled
         if hasattr(node, 'callspec'):

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -424,7 +424,7 @@ def pytest_runtest_setup(item):
         for name in marker.kwargs:
             if name not in (
                     "max_time", "min_rounds", "min_time", "timer", "group", "disable_gc", "warmup",
-                    "warmup_iterations", "calibration_precision", "cprofile"):
+                    "warmup_iterations", "calibration_precision", "cprofile", "baseline"):
                 raise ValueError("benchmark mark can't have %r keyword argument." % name)
 
 

--- a/src/pytest_benchmark/stats.py
+++ b/src/pytest_benchmark/stats.py
@@ -172,6 +172,7 @@ class Stats(object):
 class Metadata(object):
     def __init__(self, fixture, iterations, options):
         self.name = fixture.name
+        self.baseline = fixture.baseline
         self.fullname = fixture.fullname
         self.group = fixture.group
         self.param = fixture.param
@@ -210,6 +211,7 @@ class Metadata(object):
         result = {
             "group": self.group,
             "name": self.name,
+            "baseline": self.baseline,
             "fullname": self.fullname,
             "params": self.params,
             "param": self.param,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1096,3 +1096,26 @@ def test_columns(testdir):
         "Name (time in ?s) * Max * Iterations * Min *",
         "------*",
     ])
+
+
+def test_report_table_order(testdir):
+    test = testdir.makepyfile('''
+import time
+import pytest
+
+@pytest.mark.benchmark(baseline=False)
+def test_fast(benchmark):
+    @benchmark
+    def result():
+        return time.sleep(0.000001)
+    assert result == None
+
+def test_slow(benchmark):
+    benchmark(lambda: time.sleep(0.1))
+    assert 1 == 1
+''')
+    result = testdir.runpytest_subprocess(test)
+    result.stdout.fnmatch_lines([
+        "test_fast         * (0.*)  *",
+        "test_slow         * (1.0)  *"
+    ])


### PR DESCRIPTION
Add `baseline` option that determines (according to the included docs):

    Whether this benchmark's results should be considered as possible
    base line values when comparing them to other results of the same
    group? Use this if you want to include some results just for
    comparison, without them affecting the relative scores displayed
    for other results.
