### PR TITLE
Add `py` to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     install_requires=[
         'pytest>=3.8',
         'py-cpuinfo',
+        'py>=1.8.2',
     ],
     extras_require={
         'aspect': ['aspectlib'],


### PR DESCRIPTION
This is needed since `py` is used but not explicitly listed. Pytest 7.2 no longer requires `py`, which breaks pytest-benchmark with this version of pytest.

Fixes #226