### PR TITLE
Fix typo and broken link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -152,7 +152,7 @@ Changelog
 3.1.0a1 (2016-10-29)
 --------------------
 
-* Added ``--benchmark-colums`` command line option. It selects what columns are displayed in the result table. Contributed by
+* Added ``--benchmark-columns`` command line option. It selects what columns are displayed in the result table. Contributed by
   Antonio Cuni in `#34 <https://github.com/ionelmc/pytest-benchmark/pull/34>`_.
 * Added support for grouping by specific test parametrization (``--benchmark-group-by=param:NAME`` where ``NAME`` is your
   param name). Contributed by Antonio Cuni in `#37 <https://github.com/ionelmc/pytest-benchmark/pull/37>`__.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To set up `pytest-benchmark` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes run all the checks and docs builder with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
+4. When you're done making changes run all the checks and docs builder with `tox <https://tox.wiki/en/latest/installation.html>`_ one command::
 
     tox
 


### PR DESCRIPTION
Tiny improvement to documentation. It's good to remove typos in code / cli arguments.