### PR TITLE
Adjust for shortened PyTest output

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -952,7 +952,6 @@ def test_ok(benchmark, bad_fixture):
 
         "    def test_bad(benchmark):",
         "?       @benchmark",
-        "?       def result():",
 
         "test_abort_broken.py:*",
         "_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _*",


### PR DESCRIPTION
The code dump in PyTest has shorter context now. Removing the matching line is backwards compatible and fixes the test suite for the latest PyTest 7.4.2 release.