### PR TITLE
Upgrade GitHub Actions checkout@v4

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1028,7 +1028,7 @@ jobs:
             tox_env: 'pypy39-pytest72-xdist-nocov'
             os: 'macos-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     cover: coverage
     pypy: jitviewer
     aspectlib==2.0.0
-    pygal==3.0.0
+    pygal==3.0.4
     pygaljs==1.0.2
     freezegun==1.2.2
     hunter


### PR DESCRIPTION
https://github.com/actions/checkout/releases -->
> DeprecationWarning: pkg_resources is deprecated as an API.
> See https://setuptools.pypa.io/en/latest/pkg_resources.html