### PR TITLE
Fix datetime.utcnow() deprecated in Python 3.12

### DIFF
--- a/src/pytest_benchmark/utils.py
+++ b/src/pytest_benchmark/utils.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 import sys
 import types
-from datetime import datetime
+from datetime import datetime, UTC
 from decimal import Decimal
 from functools import partial
 from os.path import basename
@@ -198,7 +198,7 @@ def get_commit_info(project_name=None):
 
 
 def get_current_time():
-    return datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
 
 
 def first_or_value(obj, value):


### PR DESCRIPTION
Fixes #240
* #240 

https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow is deprecated in Python 3.12.