### PR TITLE
Add codespell support (config, pre-commit), workflow + and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
+  # Configuration for codespell is in pyproject.toml
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Overview
 ========
 
+typohere: ot
+
 .. start-badges
 
 .. list-table::

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -22,7 +22,7 @@ Why is my ``StdDev`` so high?
 Why is my ``Min`` way lower than ``Q1-1.5IQR``?
     You may see this issue in the histogram plot. This is another instance of *bad isolation*.
 
-    For example, Intel CPUs have a feature called `Turbo Boost <https://en.wikipedia.org/wiki/Intel_Turbo_Boost>`_ wich
+    For example, Intel CPUs have a feature called `Turbo Boost <https://en.wikipedia.org/wiki/Intel_Turbo_Boost>`_ which
     overclocks your CPU depending on how many cores you have at that time and how hot your CPU is. If your CPU is too hot you get
     no Turbo Boost. If you get Turbo Boost active then the CPU quickly gets hot. You can see how this won't work for sustained
     workloads.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Notable features and goals:
 * Sensible defaults and automatic calibration for microbenchmarks
 * Good integration with pytest
 * Comparison and regression tracking
-* Exhausive statistics
+* Exhaustive statistics
 * JSON export
 
 Examples:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -262,7 +262,7 @@ You can set per-test options with the ``benchmark`` marker:
 Extra info
 ==========
 
-You can set arbirary values in the ``benchmark.extra_info`` dictionary, which
+You can set arbitrary values in the ``benchmark.extra_info`` dictionary, which
 will be saved in the JSON if you use ``--benchmark-autosave`` or similar:
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,10 @@ skip-string-normalization = true
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"
+
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+[tool.codespell]
+skip = '.git,*.pdf,*.svg,go.sum'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,5 @@ inline-quotes = "single"
 skip = '.git,*.pdf,*.svg,go.sum'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# name and unfortunate choices for a few variables
+ignore-words-list = 'daa,serie,splitted'

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -759,7 +759,7 @@ def pytest_benchmark_update_machine_info(config, machine_info):
     simple_test = """
 def test_simple(benchmark):
     @benchmark
-    def resuilt():
+    def result():
         1+1
     """
 


### PR DESCRIPTION
TODOs

- [ ] remove TEMP commit after settling down on how to integrate with CI

ATM I added dedicated workflow . But it could be part of some other workflow running tox or pre-commit, yet to see what CI run might fail with my TEMP commit with a typo