### PR TITLE
remove 3.8 support from trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Support for 3.8 was dropped in 15557b06a0564880e0abd1788b3c2033b8c68073, but this was left out.