### PR TITLE
Add `-k` filtering to pytest-benchmark compare

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -233,6 +233,9 @@ The compare ``command`` takes almost all the ``--benchmark`` options, minus the 
       --csv=FILENAME        Save a csv report. If FILENAME contains slashes ('/')
                             then directories will be created. Default:
                             'benchmark_<date>_<time>'
+      -k EXPR               Only show benchmarks matching the given expression.
+                            Uses the same syntax as pytest's ``-k`` option
+                            (e.g. ``'foo and not bar'``).
 
     examples:
 

--- a/src/pytest_benchmark/cli.py
+++ b/src/pytest_benchmark/cli.py
@@ -121,6 +121,13 @@ def make_parser():
     )
     add_glob_or_file(compare_command.add_argument)
     add_csv_options(compare_command.add_argument, prefix='')
+    compare_command.add_argument(
+        '-k',
+        metavar='EXPR',
+        dest='filter_expr',
+        default=None,
+        help="Only show benchmarks matching the given expression. Uses the same syntax as pytest's -k option (e.g. 'foo and not bar').",
+    )
 
     return parser
 
@@ -183,8 +190,19 @@ def main():
                 config=Config.fromdictargs({'benchmark_time_unit': args.time_unit}, []),
             ),
         )
+        benchmarks = storage.load_benchmarks(*args.glob_or_file)
+        if args.filter_expr:
+            from _pytest.mark.expression import Expression  # noqa: PLC0415
+
+            expr = Expression.compile(args.filter_expr)
+
+            def _evaluate_expr(benchmark):
+                name = benchmark.get('fullname') or benchmark.get('name', '')
+                return expr.evaluate(lambda key: key in name)
+
+            benchmarks = filter(_evaluate_expr, benchmarks)
         groups = hook.pytest_benchmark_group_stats(
-            benchmarks=storage.load_benchmarks(*args.glob_or_file),
+            benchmarks=benchmarks,
             group_by=args.group_by,
             config=None,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,7 @@ def test_help_compare(testdir, args):
             '                                 [--time-unit COLUMN]',
             '                                 [--histogram [FILENAME-PREFIX]]',
             '                                 [--between COLUMNS] [--csv [FILENAME]]',
+            '                                 [-k EXPR]',
             '                                 [[]glob_or_file *[]]',
             '',
             'Compare saved runs.',
@@ -128,6 +129,9 @@ def test_help_compare(testdir, args):
             "  --csv [FILENAME]      Save a csv report. If FILENAME contains slashes ('/')",
             '                        then directories will be created. Default:',
             "                        'benchmark_*'",
+            '  -k EXPR               Only show benchmarks matching the given expression.',
+            "                        Uses the same syntax as pytest's -k option (e.g. 'foo",
+            "                        and not bar').",
             '',
             'examples:',
             '',
@@ -429,3 +433,35 @@ def test_compare_csv(testdir):
     )
     result = testdir.run('py.test-benchmark', 'compare', '--csv')
     result.stderr.fnmatch_lines(['Generated csv: *.csv'])
+
+
+def test_compare_filter(testdir):
+    test = testdir.makepyfile("""
+    import pytest
+    @pytest.mark.parametrize("arg", ["foo", "bar"])
+    def test_alpha(benchmark, arg):
+        benchmark(lambda: None)
+    def test_beta(benchmark):
+        benchmark(lambda: None)
+    """)
+    result = testdir.runpytest_subprocess('--benchmark-autosave', test)
+    result.stderr.fnmatch_lines(['Saved benchmark data in: *'])
+
+    # Filter to only test_alpha benchmarks
+    result = testdir.run('py.test-benchmark', 'compare', '-k', 'alpha', '--columns', 'min,max')
+    result.stdout.fnmatch_lines(['*benchmark: 2 tests*'])
+    assert 'test_beta' not in result.stdout.str()
+
+    # Filter with "not" expression
+    result = testdir.run('py.test-benchmark', 'compare', '-k', 'not alpha', '--columns', 'min,max')
+    result.stdout.fnmatch_lines(['*benchmark: 1 tests*'])
+    assert 'test_alpha' not in result.stdout.str()
+
+    # Filter with "and" expression
+    result = testdir.run('py.test-benchmark', 'compare', '-k', 'alpha and foo', '--columns', 'min,max')
+    result.stdout.fnmatch_lines(['*benchmark: 1 tests*'])
+    assert 'bar' not in result.stdout.str()
+
+    # No filter shows all
+    result = testdir.run('py.test-benchmark', 'compare', '--columns', 'min,max')
+    result.stdout.fnmatch_lines(['*benchmark: 3 tests*'])


### PR DESCRIPTION
... just like `pytest -k`, and using the same machinery.

```
$ pytest-benchmark compare .benchmarks/Darwin-CPython-3.14-64bit/*.json -kmultiple --columns=ops

---------------------- benchmark: 4 tests ---------------------
Name (time in us)                                 OPS
---------------------------------------------------------------
test_aggregate_multiple (0001_main-ad)     3,787.8262 (0.98)
test_aggregate_multiple (0002_sql-mic)     3,874.5312 (1.0)
test_order_by_multiple (0001_main-ad)        684.4064 (0.18)
test_order_by_multiple (0002_sql-mic)        694.5633 (0.18)
---------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```