### PR TITLE
Move test deps to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,12 @@ pytest-benchmark = "pytest_benchmark.cli:main"
 "Changelog" = "https://pytest-benchmark.readthedocs.io/en/latest/changelog.html"
 "Issue Tracker" = "https://github.com/ionelmc/pytest-benchmark/issues"
 
+[dependency-groups]
+dev = [
+    "freezegun>=1.5.5",
+    "nbmake>=1.5.5",
+]
+
 [tool.mypy]
 exclude = ['build']
 

--- a/tests/test_elasticsearch_storage.py
+++ b/tests/test_elasticsearch_storage.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip('elasticsearch')
+
 import json
 import logging
 from io import BytesIO
@@ -5,7 +9,6 @@ from io import StringIO
 from pathlib import Path
 
 import elasticsearch
-import pytest
 from freezegun import freeze_time
 
 from pytest_benchmark import plugin

--- a/tox.ini
+++ b/tox.ini
@@ -32,22 +32,22 @@ package = wheel
 usedevelop =
     cover: true
     nocov: false
+dependency_groups =
+    dev
+extras =
+    aspect
+    elasticsearch
+    histogram
 deps =
-    xdist: pytest-xdist==3.8.0
-    pytest84: pytest==8.4.2
-    pytest90: pytest==9.0.2
-    cover: pytest-cov
-    setuptools>=80
     cover: coverage
-    pypy: jitviewer
-    aspectlib==2.0.0
+    cover: pytest-cov
     pygal==3.1.0
     pygaljs==1.0.2
-    freezegun
-    hunter
-    setuptools
-    elasticsearch==9.3.0
-    nbmake
+    pypy: jitviewer
+    pytest84: pytest==8.4.2
+    pytest90: pytest==9.0.2
+    setuptools>=80
+    xdist: pytest-xdist==3.8.0
 commands =
     nocov: {posargs:pytest -vv --ignore=src}
     cover: {posargs:pytest --cov --cov-report=term-missing --cov-report=xml -vv}


### PR DESCRIPTION
This makes it possible to just run `uv run pytest`; previously you'd have to additionally know to install freezegun and nbmake... While at it, it removes the duplicated deps from `tox.ini`; the same things are available the package `extras` anyway.

Tests in general are fixed in #306. 