### PR TITLE
Fix compute_timer_precision to not always take 1 second

### DIFF
--- a/src/pytest_benchmark/timers.py
+++ b/src/pytest_benchmark/timers.py
@@ -23,7 +23,8 @@ def compute_timer_precision(timer):
     points = 0
     timeout = timeout_timer() + 1.0
     previous = timer()
-    while timeout_timer() < timeout or points < 5:
+    # Stop as soon as we have enough data points or the timeout expires.
+    while timeout_timer() < timeout and points < 100:
         for _ in range(10):
             t1 = timer()
             t2 = timer()


### PR DESCRIPTION
I was [`viztracer`](https://github.com/gaogaotiantian/viztracer)ing `pytest-benchmark` (because I had given up on fastidiously running tests locally because it was slow 😄) and noticed `compute_timer_precision()` always took a suspicious exactly-one-second.

Looks like the code had a little logic issue so it _always_ took up to the timeout, even if there were enough data points to go on with.

This PR proposes to fix that logic bug (`and` instead of `or`), and then increases the minimum number of data points to 100.

```
(master) $ python3 -m timeit -s 'from pytest_benchmark.timers import compute_timer_precision, default_timer' 'compute_timer_precision(default_timer)'
1 loop, best of 5: 1e+03 msec per loop
(faster-calibration) $ python3 -m timeit -s 'from pytest_benchmark.timers import compute_timer_precision, default_timer' 'compute_timer_precision(default_timer)'
10000 loops, best of 5: 22.7 usec per loop
```

This means that for each of the `pytest` subprocesses spawned by the test suite, there's about 1 second less of waiting...