### PR TITLE
Use py-cpuinfo2 fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         additional_dependencies:
           - pytest
           - freezegun
-          - py-cpuinfo
+          - py-cpuinfo2
           - jinja2
           - types-setuptools
           - elasticsearch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ keywords = [
 requires-python = ">=3.10"
 dependencies = [
     "pytest>=8.1",
-    "py-cpuinfo",
+    "py-cpuinfo2>=10.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
[py-cpuinfo](https://github.com/workhorsy/py-cpuinfo) hasn't seen a new version in 4 years, and the author says they don't have time to maintain things.

This switches to [my fork of it](https://github.com/akx/py-cpuinfo2); API compatible in the 10.x series, but much faster (no subprocesses spawned for every call).