### PR TITLE
Add type stubs for `BenchmarkFixture`

### DIFF
--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -1,9 +1,10 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import overload
 
 if TYPE_CHECKING:
     import cProfile
-
 
 # Compound Types
 type Args = tuple[Any, ...] | tuple[()]
@@ -11,9 +12,7 @@ type Kwargs = dict[str, Any]
 type SetupFunc = Callable[[], tuple[Args, Kwargs]]
 type TeardownFunc = Callable[[], Any]
 
-
 class BenchmarkFixture:
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.name: str
         self.fullname: str
@@ -28,10 +27,10 @@ class BenchmarkFixture:
         self.cprofile: cProfile.Profile
         self.cprofile_loops: int | None
         self.cprofile_dump: str | None
-        
+
         # Narrow types for stats?
         self.cprofile_stats: dict[Any, Any] | None
-        self.stats: dict[Any, Any] | None 
+        self.stats: dict[Any, Any] | None
 
     @property
     def enabled(self) -> bool: ...
@@ -42,41 +41,39 @@ class BenchmarkFixture:
     # Provided `args` and/or `kwargs` (prevent `setup`)
     @overload
     def pedantic[**P, R](
-        self, 
-        target: Callable[P, R], 
-        args: Args = ..., 
+        self,
+        target: Callable[P, R],
+        args: Args = ...,
         kwargs: Kwargs | None = ...,
-        *, 
-        teardown: TeardownFunc | None = ..., 
-        rounds: int = ..., 
-        warmup_rounds: int = ..., 
+        *,
+        teardown: TeardownFunc | None = ...,
+        rounds: int = ...,
+        warmup_rounds: int = ...,
         iterations: int = ...,
     ) -> R: ...
     # Provided `setup` (prevent `args`/`kwargs`)
     @overload
     def pedantic[**P, R](
-        self, 
-        target: Callable[P, R], 
+        self,
+        target: Callable[P, R],
         *,
-        setup: SetupFunc | None = ..., 
-        teardown: TeardownFunc | None = ..., 
-        rounds: int = ..., 
-        warmup_rounds: int = ..., 
+        setup: SetupFunc | None = ...,
+        teardown: TeardownFunc | None = ...,
+        rounds: int = ...,
+        warmup_rounds: int = ...,
         iterations: int = ...,
     ) -> R: ...
     def pedantic[**P, R](
-        self, 
-        target: Callable[P, R], 
-        args: Args = (), 
-        kwargs: Kwargs | None = None, 
-        setup: SetupFunc | None = None, 
-        teardown: TeardownFunc | None = None, 
-        rounds: int = 1, 
-        warmup_rounds: int = 0, 
-        iterations: int = 1
+        self,
+        target: Callable[P, R],
+        args: Args = (),
+        kwargs: Kwargs | None = None,
+        setup: SetupFunc | None = None,
+        teardown: TeardownFunc | None = None,
+        rounds: int = 1,
+        warmup_rounds: int = 0,
+        iterations: int = 1,
     ) -> R: ...
-    
     def weave[**P, R](self, target: Callable[P, R], **kwargs: Any) -> None: ...
 
     patch = weave
-    

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -1,14 +1,14 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Never, overload
+from typing import TYPE_CHECKING, Any, overload
 
 if TYPE_CHECKING:
     import cProfile
 
 
 # Compound Types
-type Args = tuple[Any, ...] | tuple[Never]
+type Args = tuple[Any, ...] | tuple[()]
 type Kwargs = dict[str, Any]
-type SetupFunc = Callable[[], tuple[tuple[Any, ...], dict[str, Any]]]
+type SetupFunc = Callable[[], tuple[Args, Kwargs]]
 type TeardownFunc = Callable[[], Any]
 
 
@@ -42,7 +42,7 @@ class BenchmarkFixture:
     # Provided `args` and/or `kwargs` (prevent `setup`)
     @overload
     def pedantic[**P, R](self, target: Callable[P, R], 
-                         args: Args, kwargs: Kwargs | None,
+                         args: Args=..., kwargs: Kwargs | None=...,
                          *, 
                          teardown: TeardownFunc| None=..., rounds: int=..., warmup_rounds: int=..., iterations: int=...) -> R: ...
     # Provided `setup` (prevent `args`/`kwargs`)

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -41,28 +41,42 @@ class BenchmarkFixture:
 
     # Provided `args` and/or `kwargs` (prevent `setup`)
     @overload
-    def pedantic[**P, R](self, target: Callable[P, R], 
-                         args: Args=..., kwargs: Kwargs | None=...,
-                         *, 
-                         teardown: TeardownFunc| None=..., rounds: int=..., warmup_rounds: int=..., iterations: int=...) -> R: ...
+    def pedantic[**P, R](
+        self, 
+        target: Callable[P, R], 
+        args: Args = ..., 
+        kwargs: Kwargs | None = ...,
+        *, 
+        teardown: TeardownFunc | None = ..., 
+        rounds: int = ..., 
+        warmup_rounds: int = ..., 
+        iterations: int = ...,
+    ) -> R: ...
     # Provided `setup` (prevent `args`/`kwargs`)
     @overload
-    def pedantic[**P, R](self, target: Callable[P, R], 
-                         *,
-                         setup: SetupFunc, 
-                         teardown: Callable[[], Any] | None=..., rounds: int=..., warmup_rounds: int=..., iterations: int=...) -> R: ...
     def pedantic[**P, R](
-            self, 
-            target: Callable[P, R], 
-            args: Args = (), 
-            kwargs: Kwargs | None = None, 
-            setup: SetupFunc | None = None, 
-            teardown: TeardownFunc | None = None, 
-            rounds: int = 1, 
-            warmup_rounds: int = 0, 
-            iterations: int = 1
-        ) -> R: ...
+        self, 
+        target: Callable[P, R], 
+        *,
+        setup: SetupFunc | None = ..., 
+        teardown: TeardownFunc | None = ..., 
+        rounds: int = ..., 
+        warmup_rounds: int = ..., 
+        iterations: int = ...,
+    ) -> R: ...
+    def pedantic[**P, R](
+        self, 
+        target: Callable[P, R], 
+        args: Args = (), 
+        kwargs: Kwargs | None = None, 
+        setup: SetupFunc | None = None, 
+        teardown: TeardownFunc | None = None, 
+        rounds: int = 1, 
+        warmup_rounds: int = 0, 
+        iterations: int = 1
+    ) -> R: ...
     
     def weave[**P, R](self, target: Callable[P, R], **kwargs: Any) -> None: ...
 
     patch = weave
+    

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -1,48 +1,57 @@
+import cProfile
+import pstats
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Hashable
 from typing import Any
+from typing import ParamSpec
+from typing import TypeAlias
+from typing import TypeVar
 from typing import overload
 
-if TYPE_CHECKING:
-    import cProfile
+from .stats import Metadata
 
-# Compound Types
-type Args = tuple[Any, ...] | tuple[()]
-type Kwargs = dict[str, Any]
-type SetupFunc = Callable[[], tuple[Args, Kwargs]]
-type TeardownFunc = Callable[[], Any]
+statistics: Any
+statistics_error: str | None
 
 class BenchmarkFixture:
+    Args: TypeAlias = tuple[Any, ...] | tuple[()]
+    Kwargs: TypeAlias = dict[str, Any]
+    SetupFunc: TypeAlias = Callable[..., tuple[Args, Kwargs]]
+    TeardownFunc: TypeAlias = Callable[..., Any]
+
+    _P = ParamSpec('_P')
+    _R = TypeVar('_R')
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.name: str
         self.fullname: str
         self.disabled: bool
         self.param: str | None
-        self.params: tuple[str, ...] | None
+        self.params: dict[str, Any] | None
         self.group: str | None
         self.has_error: bool
-        self.extra_info: dict[str, Any]
+        self.extra_info: dict[Hashable, Any]
         self.skipped: bool
 
         self.cprofile: cProfile.Profile
         self.cprofile_loops: int | None
         self.cprofile_dump: str | None
 
-        # Narrow types for stats?
-        self.cprofile_stats: dict[Any, Any] | None
-        self.stats: dict[Any, Any] | None
+        self.cprofile_stats: pstats.Stats | None
+        self.stats: Metadata | None
 
     @property
     def enabled(self) -> bool: ...
-
-    # Expose `function_to_benchmark` *args/**kwargs to `__call__`
-    def __call__[**P, R](self, function_to_benchmark: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R: ...
-
-    # Provided `args` and/or `kwargs` (prevent `setup`)
-    @overload
-    def pedantic[**P, R](
+    def __call__(  # Expose `function_to_benchmark` *args/**kwargs to `__call__`
         self,
-        target: Callable[P, R],
+        function_to_benchmark: Callable[_P, _R],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _R: ...
+    @overload
+    def pedantic(  # Provided `args` and/or `kwargs` (prevent `setup`)
+        self,
+        target: Callable[_P, _R],
         args: Args = ...,
         kwargs: Kwargs | None = ...,
         *,
@@ -50,30 +59,22 @@ class BenchmarkFixture:
         rounds: int = ...,
         warmup_rounds: int = ...,
         iterations: int = ...,
-    ) -> R: ...
-    # Provided `setup` (prevent `args`/`kwargs`)
+    ) -> _R: ...
     @overload
-    def pedantic[**P, R](
+    def pedantic(  # Provided `setup` (prevent `args`/`kwargs`)
         self,
-        target: Callable[P, R],
+        target: Callable[_P, _R],
         *,
         setup: SetupFunc | None = ...,
         teardown: TeardownFunc | None = ...,
         rounds: int = ...,
         warmup_rounds: int = ...,
         iterations: int = ...,
-    ) -> R: ...
-    def pedantic[**P, R](
+    ) -> _R: ...
+    def weave(
         self,
-        target: Callable[P, R],
-        args: Args = (),
-        kwargs: Kwargs | None = None,
-        setup: SetupFunc | None = None,
-        teardown: TeardownFunc | None = None,
-        rounds: int = 1,
-        warmup_rounds: int = 0,
-        iterations: int = 1,
-    ) -> R: ...
-    def weave[**P, R](self, target: Callable[P, R], **kwargs: Any) -> None: ...
+        target: Callable[_P, _R],
+        **kwargs: Any,
+    ) -> None: ...
 
     patch = weave

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -1,0 +1,68 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Never, overload
+
+if TYPE_CHECKING:
+    import cProfile
+
+
+# Compound Types
+type Args = tuple[Any, ...] | tuple[Never]
+type Kwargs = dict[str, Any]
+type SetupFunc = Callable[[], tuple[tuple[Any, ...], dict[str, Any]]]
+type TeardownFunc = Callable[[], Any]
+
+
+class BenchmarkFixture:
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.name: str
+        self.fullname: str
+        self.disabled: bool
+        self.param: str | None
+        self.params: tuple[str, ...] | None
+        self.group: str
+        self.has_error: bool
+        self.extra_info: dict[str, Any]
+        self.skipped: bool
+
+        self.cprofile: cProfile.Profile
+        self.cprofile_loops: int | None
+        self.cprofile_dump: str | None
+        
+        # Narrow types for stats?
+        self.cprofile_stats: dict[Any, Any] | None
+        self.stats: dict[Any, Any] | None 
+
+    @property
+    def enabled(self) -> bool: ...
+
+    # Expose `function_to_benchmark` *args/**kwargs to `__call__`
+    def __call__[**P, R](self, function_to_benchmark: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+    # Provided `args` and/or `kwargs` (prevent `setup`)
+    @overload
+    def pedantic[**P, R](self, target: Callable[P, R], 
+                         args: Args, kwargs: Kwargs | None,
+                         *, 
+                         teardown: TeardownFunc| None=..., rounds: int=..., warmup_rounds: int=..., iterations: int=...) -> R: ...
+    # Provided `setup` (prevent `args`/`kwargs`)
+    @overload
+    def pedantic[**P, R](self, target: Callable[P, R], 
+                         *,
+                         setup: SetupFunc, 
+                         teardown: Callable[[], Any] | None=..., rounds: int=..., warmup_rounds: int=..., iterations: int=...) -> R: ...
+    def pedantic[**P, R](
+            self, 
+            target: Callable[P, R], 
+            args: Args = (), 
+            kwargs: Kwargs | None = None, 
+            setup: SetupFunc | None = None, 
+            teardown: TeardownFunc | None = None, 
+            rounds: int = 1, 
+            warmup_rounds: int = 0, 
+            iterations: int = 1
+        ) -> R: ...
+    
+    def weave[**P, R](self, target: Callable[P, R], **kwargs: Any) -> None: ...
+
+    patch = weave

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -13,15 +13,15 @@ from .stats import Metadata
 statistics: Any
 statistics_error: str | None
 
+_Args: TypeAlias = tuple[Any, ...] | tuple[()]
+_Kwargs: TypeAlias = dict[str, Any]
+_SetupFunc: TypeAlias = Callable[..., tuple[_Args, _Kwargs]]
+_TeardownFunc: TypeAlias = Callable[..., Any]
+
+_P = ParamSpec('_P')
+_R = TypeVar('_R')
+
 class BenchmarkFixture:
-    Args: TypeAlias = tuple[Any, ...] | tuple[()]
-    Kwargs: TypeAlias = dict[str, Any]
-    SetupFunc: TypeAlias = Callable[..., tuple[Args, Kwargs]]
-    TeardownFunc: TypeAlias = Callable[..., Any]
-
-    _P = ParamSpec('_P')
-    _R = TypeVar('_R')
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.name: str
         self.fullname: str
@@ -52,10 +52,10 @@ class BenchmarkFixture:
     def pedantic(  # Provided `args` and/or `kwargs` (prevent `setup`)
         self,
         target: Callable[_P, _R],
-        args: Args = ...,
-        kwargs: Kwargs | None = ...,
+        args: _Args = ...,
+        kwargs: _Kwargs | None = ...,
         *,
-        teardown: TeardownFunc | None = ...,
+        teardown: _TeardownFunc | None = ...,
         rounds: int = ...,
         warmup_rounds: int = ...,
         iterations: int = ...,
@@ -65,8 +65,8 @@ class BenchmarkFixture:
         self,
         target: Callable[_P, _R],
         *,
-        setup: SetupFunc | None = ...,
-        teardown: TeardownFunc | None = ...,
+        setup: _SetupFunc | None = ...,
+        teardown: _TeardownFunc | None = ...,
         rounds: int = ...,
         warmup_rounds: int = ...,
         iterations: int = ...,

--- a/src/pytest_benchmark/fixture.pyi
+++ b/src/pytest_benchmark/fixture.pyi
@@ -20,7 +20,7 @@ class BenchmarkFixture:
         self.disabled: bool
         self.param: str | None
         self.params: tuple[str, ...] | None
-        self.group: str
+        self.group: str | None
         self.has_error: bool
         self.extra_info: dict[str, Any]
         self.skipped: bool

--- a/src/pytest_benchmark/stats.pyi
+++ b/src/pytest_benchmark/stats.pyi
@@ -4,11 +4,13 @@ from functools import cached_property
 from typing import Any
 from typing import Literal
 from typing import NotRequired
+from typing import TypeAlias
 from typing import TypedDict
 from typing import TypeVar
-from typing import overload
 
 from .fixture import BenchmarkFixture
+
+_D = TypeVar('_D')
 
 # Typed Dicts for as_dict returns
 
@@ -41,6 +43,10 @@ class _cprofile_stats(TypedDict):
 
 # Each flag for Metadata.as_dict() can change the included keys
 
+class _MetadataDict_stats(_StatsDict):
+    iterations: int
+    data: NotRequired[list[float]]
+
 class _MetadataDict(TypedDict):
     group: str | None
     name: str
@@ -50,21 +56,9 @@ class _MetadataDict(TypedDict):
     extra_info: dict[Hashable, Any]
     options: dict[str, Any]
     cprofile: NotRequired[list[_cprofile_stats]]
+    stats: NotRequired[_MetadataDict_stats]
 
-class _MetadataDict_stats(_StatsDict):
-    iterations: int
-
-class _MetadataDict_stats_data(_MetadataDict_stats):
-    data: list[float]
-
-class _MetadataDict_stats_flat(_MetadataDict, _MetadataDict_stats): ...
-class _MetadataDict_stats_data_flat(_MetadataDict, _MetadataDict_stats_data): ...
-
-class _MetadataDict_stats_nonflat(_MetadataDict):
-    stats: _MetadataDict_stats
-
-class _MetadataDict_stats_data_nonflat(_MetadataDict):
-    stats: _MetadataDict_stats_data
+class _FlatMetadataDict(_MetadataDict, _StatsDict): ...
 
 cProfileStats = Literal[
     'cumtime',
@@ -94,6 +88,9 @@ Field = Literal[
     'ops',
     'total',
 ]
+
+
+cProfileFilter: TypeAlias = tuple[cProfileStats | None, int]
 
 class Stats:
     fields: tuple[Field, ...]
@@ -140,8 +137,8 @@ class Stats:
     @cached_property
     def ops(self) -> float: ...
 
+
 class Metadata:
-    _D = TypeVar('_D')
 
     def __init__(self, fixture: BenchmarkFixture, iterations: int, options: dict[str, Any]) -> None:
         self.name: str
@@ -163,46 +160,13 @@ class Metadata:
     def __getitem__(self, key: str) -> Any: ...
     @property
     def has_error(self) -> bool: ...
-    @overload
-    def as_dict(  # no stats
+    def as_dict(
         self,
-        include_data: bool = ...,
-        flat: bool = ...,
-        stats: Literal[False] = False,
-        cprofile: tuple[cProfileStats | None, int] | None = ...,
-    ) -> _MetadataDict: ...
-    @overload
-    def as_dict(  # stats
-        self,
-        include_data: Literal[False] = False,
-        flat: Literal[False] = False,
-        stats: Literal[True] = True,
-        cprofile: tuple[cProfileStats | None, int] | None = ...,
-    ) -> _MetadataDict_stats_nonflat: ...
-    @overload
-    def as_dict(  # flat stats
-        self,
-        include_data: Literal[False] = False,
-        flat: Literal[True] = True,
-        stats: Literal[True] = True,
-        cprofile: tuple[cProfileStats | None, int] | None = ...,
-    ) -> _MetadataDict_stats_flat: ...
-    @overload
-    def as_dict(  # stats with data
-        self,
-        include_data: Literal[True] = True,
-        flat: Literal[False] = False,
-        stats: Literal[True] = True,
-        cprofile: tuple[cProfileStats | None, int] | None = ...,
-    ) -> _MetadataDict_stats_data_nonflat: ...
-    @overload
-    def as_dict(  # flat stats with data
-        self,
-        include_data: Literal[True] = True,
-        flat: Literal[True] = True,
-        stats: Literal[True] = True,
-        cprofile: tuple[cProfileStats | None, int] | None = ...,
-    ) -> _MetadataDict_stats_data_flat: ...
+        include_data: bool = True,
+        flat: bool = False,
+        stats: bool = True,
+        cprofile: cProfileFilter | None = ...,
+    ) -> _MetadataDict | _FlatMetadataDict: ...
     def update(self, duration: float) -> None: ...
 
 def normalize_stats(stats: Stats) -> Stats: ...

--- a/src/pytest_benchmark/stats.pyi
+++ b/src/pytest_benchmark/stats.pyi
@@ -39,7 +39,6 @@ class _cprofile_stats(TypedDict):
     cumime_per: float
     function_name: str
 
-
 # Each flag for Metadata.as_dict() can change the included keys
 
 class _MetadataDict(TypedDict):
@@ -63,9 +62,9 @@ class _MetadataDict_stats_data_flat(_MetadataDict, _MetadataDict_stats_data): ..
 
 class _MetadataDict_stats_nonflat(_MetadataDict):
     stats: _MetadataDict_stats
+
 class _MetadataDict_stats_data_nonflat(_MetadataDict):
     stats: _MetadataDict_stats_data
-
 
 cProfileStats = Literal[
     'cumtime',
@@ -160,12 +159,12 @@ class Metadata:
 
     def __bool__(self) -> bool: ...
     def __nonzero__(self) -> bool: ...
-    def get(self, key: str, default: _D = None) -> Any | _D: ...
+    def get(self, key: str, default: _D = ...) -> Any | _D: ...
     def __getitem__(self, key: str) -> Any: ...
     @property
     def has_error(self) -> bool: ...
     @overload
-    def as_dict( # no stats
+    def as_dict(  # no stats
         self,
         include_data: bool = ...,
         flat: bool = ...,
@@ -173,7 +172,7 @@ class Metadata:
         cprofile: tuple[cProfileStats | None, int] | None = ...,
     ) -> _MetadataDict: ...
     @overload
-    def as_dict( # stats
+    def as_dict(  # stats
         self,
         include_data: Literal[False] = False,
         flat: Literal[False] = False,
@@ -181,7 +180,7 @@ class Metadata:
         cprofile: tuple[cProfileStats | None, int] | None = ...,
     ) -> _MetadataDict_stats_nonflat: ...
     @overload
-    def as_dict( # flat stats
+    def as_dict(  # flat stats
         self,
         include_data: Literal[False] = False,
         flat: Literal[True] = True,
@@ -189,7 +188,7 @@ class Metadata:
         cprofile: tuple[cProfileStats | None, int] | None = ...,
     ) -> _MetadataDict_stats_flat: ...
     @overload
-    def as_dict( # stats with data
+    def as_dict(  # stats with data
         self,
         include_data: Literal[True] = True,
         flat: Literal[False] = False,
@@ -197,7 +196,7 @@ class Metadata:
         cprofile: tuple[cProfileStats | None, int] | None = ...,
     ) -> _MetadataDict_stats_data_nonflat: ...
     @overload
-    def as_dict( # flat stats with data
+    def as_dict(  # flat stats with data
         self,
         include_data: Literal[True] = True,
         flat: Literal[True] = True,

--- a/src/pytest_benchmark/stats.pyi
+++ b/src/pytest_benchmark/stats.pyi
@@ -1,0 +1,209 @@
+import pstats
+from collections.abc import Hashable
+from functools import cached_property
+from typing import Any
+from typing import Literal
+from typing import NotRequired
+from typing import TypedDict
+from typing import TypeVar
+from typing import overload
+
+from .fixture import BenchmarkFixture
+
+# Typed Dicts for as_dict returns
+
+class _StatsDict(TypedDict):
+    min: float
+    max: float
+    mean: float
+    stddev: float
+    rounds: int
+    median: float
+    iqr: float
+    q1: float
+    q3: float
+    iqr_outliers: int | str
+    stddev_outliers: int
+    outliers: int | str
+    ld15iqr: float
+    hd15iqr: float
+    ops: float
+    total: float
+
+class _cprofile_stats(TypedDict):
+    ncalls_recursion: str
+    ncalls: int
+    tottime: float
+    tottime_per: float
+    cumtime: float
+    cumime_per: float
+    function_name: str
+
+
+# Each flag for Metadata.as_dict() can change the included keys
+
+class _MetadataDict(TypedDict):
+    group: str | None
+    name: str
+    fullname: str
+    params: dict[str, Any] | None
+    param: str | None
+    extra_info: dict[Hashable, Any]
+    options: dict[str, Any]
+    cprofile: NotRequired[list[_cprofile_stats]]
+
+class _MetadataDict_stats(_StatsDict):
+    iterations: int
+
+class _MetadataDict_stats_data(_MetadataDict_stats):
+    data: list[float]
+
+class _MetadataDict_stats_flat(_MetadataDict, _MetadataDict_stats): ...
+class _MetadataDict_stats_data_flat(_MetadataDict, _MetadataDict_stats_data): ...
+
+class _MetadataDict_stats_nonflat(_MetadataDict):
+    stats: _MetadataDict_stats
+class _MetadataDict_stats_data_nonflat(_MetadataDict):
+    stats: _MetadataDict_stats_data
+
+
+cProfileStats = Literal[
+    'cumtime',
+    'tottime',
+    'ncalls',
+    'ncalls_recursion',
+    'tottime_per',
+    'cumtime_per',
+    'function_name',
+]
+
+Field = Literal[
+    'min',
+    'max',
+    'mean',
+    'stddev',
+    'rounds',
+    'median',
+    'iqr',
+    'q1',
+    'q3',
+    'iqr_outliers',
+    'stddev_outliers',
+    'outliers',
+    'ld15iqr',
+    'hd15iqr',
+    'ops',
+    'total',
+]
+
+class Stats:
+    fields: tuple[Field, ...]
+
+    def __init__(self) -> None:
+        self.data: list[float]
+
+    def __bool__(self) -> bool: ...
+    def __nonzero__(self) -> bool: ...
+    def as_dict(self) -> _StatsDict: ...
+    def update(self, duration: float) -> None: ...
+    @cached_property
+    def sorted_data(self) -> list[float]: ...
+    @cached_property
+    def total(self) -> float: ...
+    @cached_property
+    def min(self) -> float: ...
+    @cached_property
+    def max(self) -> float: ...
+    @cached_property
+    def mean(self) -> float: ...
+    @cached_property
+    def stddev(self) -> float: ...
+    @property
+    def stddev_outliers(self) -> int: ...
+    @cached_property
+    def rounds(self) -> int: ...
+    @cached_property
+    def median(self) -> float: ...
+    @cached_property
+    def ld15iqr(self) -> float: ...
+    @cached_property
+    def hd15iqr(self) -> float: ...
+    @cached_property
+    def q1(self) -> float: ...
+    @cached_property
+    def q3(self) -> float: ...
+    @cached_property
+    def iqr(self) -> float: ...
+    @cached_property
+    def iqr_outliers(self) -> int: ...
+    @cached_property
+    def outliers(self) -> str: ...
+    @cached_property
+    def ops(self) -> float: ...
+
+class Metadata:
+    _D = TypeVar('_D')
+
+    def __init__(self, fixture: BenchmarkFixture, iterations: int, options: dict[str, Any]) -> None:
+        self.name: str
+        self.fullname: str
+        self.group: str | None
+        self.param: str | None
+        self.params: dict[str, Any] | None
+        self.extra_info: dict[Hashable, Any]
+        self.cprofile_stats: pstats.Stats | None
+
+        self.iterations: int
+        self.stats: Stats | None
+        self.options: dict[str, Any]
+        self.fixture: BenchmarkFixture
+
+    def __bool__(self) -> bool: ...
+    def __nonzero__(self) -> bool: ...
+    def get(self, key: str, default: _D = None) -> Any | _D: ...
+    def __getitem__(self, key: str) -> Any: ...
+    @property
+    def has_error(self) -> bool: ...
+    @overload
+    def as_dict( # no stats
+        self,
+        include_data: bool = ...,
+        flat: bool = ...,
+        stats: Literal[False] = False,
+        cprofile: tuple[cProfileStats | None, int] | None = ...,
+    ) -> _MetadataDict: ...
+    @overload
+    def as_dict( # stats
+        self,
+        include_data: Literal[False] = False,
+        flat: Literal[False] = False,
+        stats: Literal[True] = True,
+        cprofile: tuple[cProfileStats | None, int] | None = ...,
+    ) -> _MetadataDict_stats_nonflat: ...
+    @overload
+    def as_dict( # flat stats
+        self,
+        include_data: Literal[False] = False,
+        flat: Literal[True] = True,
+        stats: Literal[True] = True,
+        cprofile: tuple[cProfileStats | None, int] | None = ...,
+    ) -> _MetadataDict_stats_flat: ...
+    @overload
+    def as_dict( # stats with data
+        self,
+        include_data: Literal[True] = True,
+        flat: Literal[False] = False,
+        stats: Literal[True] = True,
+        cprofile: tuple[cProfileStats | None, int] | None = ...,
+    ) -> _MetadataDict_stats_data_nonflat: ...
+    @overload
+    def as_dict( # flat stats with data
+        self,
+        include_data: Literal[True] = True,
+        flat: Literal[True] = True,
+        stats: Literal[True] = True,
+        cprofile: tuple[cProfileStats | None, int] | None = ...,
+    ) -> _MetadataDict_stats_data_flat: ...
+    def update(self, duration: float) -> None: ...
+
+def normalize_stats(stats: Stats) -> Stats: ...

--- a/src/pytest_benchmark/stats.pyi
+++ b/src/pytest_benchmark/stats.pyi
@@ -24,7 +24,7 @@ class _StatsDict(TypedDict):
     iqr: float
     q1: float
     q3: float
-    iqr_outliers: int | str
+    iqr_outliers: int
     stddev_outliers: int
     outliers: int | str
     ld15iqr: float
@@ -89,7 +89,6 @@ Field = Literal[
     'total',
 ]
 
-
 cProfileFilter: TypeAlias = tuple[cProfileStats | None, int]
 
 class Stats:
@@ -137,9 +136,7 @@ class Stats:
     @cached_property
     def ops(self) -> float: ...
 
-
 class Metadata:
-
     def __init__(self, fixture: BenchmarkFixture, iterations: int, options: dict[str, Any]) -> None:
         self.name: str
         self.fullname: str
@@ -165,7 +162,7 @@ class Metadata:
         include_data: bool = True,
         flat: bool = False,
         stats: bool = True,
-        cprofile: cProfileFilter | None = ...,
+        cprofile: cProfileFilter | None = None,
     ) -> _MetadataDict | _FlatMetadataDict: ...
     def update(self, duration: float) -> None: ...
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -51,3 +51,4 @@ def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
 
     # Pass `args`/`kwargs` and `setup` (Should show Type Error)
     benchmark.pedantic(len, args=tuple([]), setup=lambda: (tuple(), dict()))
+    

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,13 +1,14 @@
-from typing import Any, assert_type
 import cProfile
-
-from src.pytest_benchmark.fixture import BenchmarkFixture
+from typing import Any
+from typing import assert_type
 
 import pytest
+from src.pytest_benchmark.fixture import BenchmarkFixture
 
 pytest.mark.skip('No Run (Type Check)')
-def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
 
+
+def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
     # Attributes
     assert_type(benchmark.name, str)
     assert_type(benchmark.fullname, str)
@@ -34,21 +35,19 @@ def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
     assert_type(benchmark.__call__(len, []), int)
     assert_type(benchmark.__call__(repr, []), str)
 
-    # `args`/`kwargs` 
+    # `args`/`kwargs`
     assert_type(benchmark.pedantic(len, args=([],)), int)
     assert_type(benchmark.pedantic(len, kwargs={}), int)
-    assert_type(benchmark.pedantic(len, args=tuple(), kwargs={}), int)
-    assert_type(benchmark.pedantic(len, tuple(), {}), int)
+    assert_type(benchmark.pedantic(len, args=(), kwargs={}), int)
+    assert_type(benchmark.pedantic(len, (), {}), int)
     assert_type(benchmark.pedantic(len, kwargs={}, rounds=10, teardown=print), int)
 
     # `setup`
-    assert_type(benchmark.pedantic(len, setup=lambda: (tuple(), {})), int)
-    assert_type(benchmark.pedantic(len, setup=lambda: (([1,2,3],), {})), int)
-
+    assert_type(benchmark.pedantic(len, setup=lambda: ((), {})), int)
+    assert_type(benchmark.pedantic(len, setup=lambda: (([1, 2, 3],), {})), int)
 
     # Reverse Positionals (Should show Type Error)
-    benchmark.pedantic(len, {}, tuple())
+    benchmark.pedantic(len, {}, ())
 
     # Pass `args`/`kwargs` and `setup` (Should show Type Error)
-    benchmark.pedantic(len, args=tuple([]), setup=lambda: (tuple(), dict()))
-    
+    benchmark.pedantic(len, args=(), setup=lambda: ((), {}))

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,0 +1,53 @@
+from typing import Any, assert_type
+import cProfile
+
+from src.pytest_benchmark.fixture import BenchmarkFixture
+
+import pytest
+
+pytest.mark.skip('No Run (Type Check)')
+def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
+
+    # Attributes
+    assert_type(benchmark.name, str)
+    assert_type(benchmark.fullname, str)
+    assert_type(benchmark.disabled, bool)
+    assert_type(benchmark.param, str | None)
+    assert_type(benchmark.params, tuple[str, ...] | None)
+    assert_type(benchmark.group, str | None)
+    assert_type(benchmark.has_error, bool)
+    assert_type(benchmark.extra_info, dict[str, Any])
+    assert_type(benchmark.skipped, bool)
+    assert_type(benchmark.cprofile, cProfile.Profile)
+    assert_type(benchmark.cprofile_loops, int | None)
+    assert_type(benchmark.cprofile_dump, str | None)
+    assert_type(benchmark.cprofile_stats, dict[Any, Any] | None)
+    assert_type(benchmark.stats, dict[Any, Any] | None)
+
+    # Properties
+    assert_type(benchmark.enabled, bool)
+
+    # Methods
+
+    # Test that types are maintained when __call__ ing the fixture
+    assert_type(benchmark.__call__(map, len, 'a'), map[int])
+    assert_type(benchmark.__call__(len, []), int)
+    assert_type(benchmark.__call__(repr, []), str)
+
+    # `args`/`kwargs` 
+    assert_type(benchmark.pedantic(len, args=([],)), int)
+    assert_type(benchmark.pedantic(len, kwargs={}), int)
+    assert_type(benchmark.pedantic(len, args=tuple(), kwargs={}), int)
+    assert_type(benchmark.pedantic(len, tuple(), {}), int)
+    assert_type(benchmark.pedantic(len, kwargs={}, rounds=10, teardown=print), int)
+
+    # `setup`
+    assert_type(benchmark.pedantic(len, setup=lambda: (tuple(), {})), int)
+    assert_type(benchmark.pedantic(len, setup=lambda: (([1,2,3],), {})), int)
+
+
+    # Reverse Positionals (Should show Type Error)
+    benchmark.pedantic(len, {}, tuple())
+
+    # Pass `args`/`kwargs` and `setup` (Should show Type Error)
+    benchmark.pedantic(len, args=tuple([]), setup=lambda: (tuple(), dict()))

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,53 +1,66 @@
-import cProfile
-from typing import Any
-from typing import assert_type
+from typing import TYPE_CHECKING
 
-import pytest
-from src.pytest_benchmark.fixture import BenchmarkFixture
+if TYPE_CHECKING:
+    import cProfile
+    import pstats
+    from collections.abc import Hashable
+    from typing import Any
+    from typing import assert_type
+    from typing import type_check_only
 
-pytest.mark.skip('No Run (Type Check)')
+    from pytest_benchmark.fixture import BenchmarkFixture
+    from pytest_benchmark.stats import Metadata
 
+    @type_check_only
+    def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
+        # Attributes
+        assert_type(benchmark.name, str)
+        assert_type(benchmark.fullname, str)
+        assert_type(benchmark.disabled, bool)
+        assert_type(benchmark.param, str | None)
+        assert_type(benchmark.params, dict[str, Any] | None)
+        assert_type(benchmark.group, str | None)
+        assert_type(benchmark.has_error, bool)
+        assert_type(benchmark.extra_info, dict[Hashable, Any])
+        assert_type(benchmark.skipped, bool)
+        assert_type(benchmark.cprofile, cProfile.Profile)
+        assert_type(benchmark.cprofile_loops, int | None)
+        assert_type(benchmark.cprofile_dump, str | None)
+        assert_type(benchmark.cprofile_stats, pstats.Stats | None)
+        assert_type(benchmark.stats, Metadata | None)
 
-def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
-    # Attributes
-    assert_type(benchmark.name, str)
-    assert_type(benchmark.fullname, str)
-    assert_type(benchmark.disabled, bool)
-    assert_type(benchmark.param, str | None)
-    assert_type(benchmark.params, tuple[str, ...] | None)
-    assert_type(benchmark.group, str | None)
-    assert_type(benchmark.has_error, bool)
-    assert_type(benchmark.extra_info, dict[str, Any])
-    assert_type(benchmark.skipped, bool)
-    assert_type(benchmark.cprofile, cProfile.Profile)
-    assert_type(benchmark.cprofile_loops, int | None)
-    assert_type(benchmark.cprofile_dump, str | None)
-    assert_type(benchmark.cprofile_stats, dict[Any, Any] | None)
-    assert_type(benchmark.stats, dict[Any, Any] | None)
+        # Properties
+        assert_type(benchmark.enabled, bool)
 
-    # Properties
-    assert_type(benchmark.enabled, bool)
+        # Methods
 
-    # Methods
+        # Test that types are maintained when __call__ ing the fixture
+        assert_type(benchmark.__call__(map, len, 'a'), map[int])
+        assert_type(benchmark.__call__(len, []), int)
+        assert_type(benchmark.__call__(repr, []), str)
 
-    # Test that types are maintained when __call__ ing the fixture
-    assert_type(benchmark.__call__(map, len, 'a'), map[int])
-    assert_type(benchmark.__call__(len, []), int)
-    assert_type(benchmark.__call__(repr, []), str)
+        # `args`/`kwargs`
+        assert_type(benchmark.pedantic(len, args=([],)), int)
+        assert_type(benchmark.pedantic(len, kwargs={}), int)
+        assert_type(benchmark.pedantic(len, args=(), kwargs={}), int)
+        assert_type(benchmark.pedantic(len, (), {}), int)
+        assert_type(benchmark.pedantic(len, kwargs={}, rounds=10, teardown=print), int)
 
-    # `args`/`kwargs`
-    assert_type(benchmark.pedantic(len, args=([],)), int)
-    assert_type(benchmark.pedantic(len, kwargs={}), int)
-    assert_type(benchmark.pedantic(len, args=(), kwargs={}), int)
-    assert_type(benchmark.pedantic(len, (), {}), int)
-    assert_type(benchmark.pedantic(len, kwargs={}, rounds=10, teardown=print), int)
+        # `setup`
+        assert_type(benchmark.pedantic(len, setup=lambda: ((), {})), int)
+        assert_type(benchmark.pedantic(len, setup=lambda: (([1, 2, 3],), {})), int)
 
-    # `setup`
-    assert_type(benchmark.pedantic(len, setup=lambda: ((), {})), int)
-    assert_type(benchmark.pedantic(len, setup=lambda: (([1, 2, 3],), {})), int)
+        # Reverse Positionals (Should show Type Error)
+        benchmark.pedantic(
+            len,
+            {},  # type: ignore[call-overload]
+            (),  # type: ignore[call-overload]
+        )
 
-    # Reverse Positionals (Should show Type Error)
-    benchmark.pedantic(len, {}, ())
-
-    # Pass `args`/`kwargs` and `setup` (Should show Type Error)
-    benchmark.pedantic(len, args=(), setup=lambda: ((), {}))
+        # Pass `args`/`kwargs` and `setup` (Should show Type Error)
+        benchmark.pedantic(
+            len,
+            args=(),
+            kwargs={},
+            setup=lambda: ((), {}),  # type: ignore[call-overload]
+        )

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
     from pytest_benchmark.fixture import BenchmarkFixture
     from pytest_benchmark.stats import Metadata
+    from pytest_benchmark.stats import _FlatMetadataDict  # type: ignore
+    from pytest_benchmark.stats import _MetadataDict  # type: ignore
 
     @type_check_only
     def test_benchmarkfixture_hints(benchmark: BenchmarkFixture):
@@ -28,6 +30,9 @@ if TYPE_CHECKING:
         assert_type(benchmark.cprofile_dump, str | None)
         assert_type(benchmark.cprofile_stats, pstats.Stats | None)
         assert_type(benchmark.stats, Metadata | None)
+
+        if benchmark.stats:
+            assert_type(benchmark.stats.as_dict(), _MetadataDict | _FlatMetadataDict)
 
         # Properties
         assert_type(benchmark.enabled, bool)


### PR DESCRIPTION
Added type stub for `BenchmarkFixture` class. The typing is currently relegated to a `fixture.pyi` file to prevent modification of the actual fixture code.

There is some existing work on this in #290, but this should be hinting for most of the public API.

I have also included a new `test_stubs.py` file that tests different argument options to test that return types are properly inferred.

### Methods:
- [x] `__call__`: Infers `*args` and `**kwargs` types from ParamSpec of `function_to_benchmark`
- [x] `pedantic`: Shows Type Error when `setup` is passed with `args` and or `kwargs`, infers return from Param Spec
- [x] `weave`: Probably not neccessary since `**kwargs` are not for the target

### Attributes
- [x] `name`: `str`
- [x] `fullname`: `str`
- [x] `disabled`: `bool`
- [x] `param`: `str | None`
- [x] `params`: `tuple[str, ...] | None`
- [x] `group`: `str | None`
- [x] `has_error`: `bool`
- [x] `extra_info`: `dict[str, Any]`
- [x] `skipped`: `bool`
- [x] `cprofile`: `cProfile.Profile`
- [x] `cprofile_loops`: `int | None`
- [x] `cprofile_dump`: `str | None`
- [x] `cprofile_stats`: `dict[Any, Any] | None`
- [x] `stats`: `dict[Any, Any] | None` 


I'm not sure if it's best to roll this into the actual codebase or keep it in a `pyi` sidecar, but if it's decided that the hints should be inlined, these headers can be directly copied over.

resolves #212