### PR TITLE
Replace deprecated argparse.FileType

### DIFF
--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -3,7 +3,6 @@
   PYTEST_DONT_REWRITE
 """
 
-import argparse
 import operator
 import platform
 import sys
@@ -11,6 +10,7 @@ import traceback
 from collections import defaultdict
 from datetime import datetime
 from datetime import timezone
+from pathlib import Path
 
 import pytest
 
@@ -257,7 +257,7 @@ def pytest_addoption(parser):
     group.addoption(
         '--benchmark-json',
         metavar='PATH',
-        type=argparse.FileType('wb'),
+        type=Path,
         help='Dump a JSON report into PATH. Note that this will include the complete data (all the timings, not just the stats).',
     )
     group.addoption(

--- a/src/pytest_benchmark/session.py
+++ b/src/pytest_benchmark/session.py
@@ -137,7 +137,7 @@ class BenchmarkSession:
                 yield flat_bench
 
     def save_json(self, output_json):
-        with self.json as fh:
+        with open(self.json, mode='wb') as fh:
             fh.write(safe_dumps(output_json, ensure_ascii=True, indent=4).encode())
         self.logger.info(f'Wrote benchmark data in: {self.json}', purple=True)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,13 +50,6 @@ class Namespace:
             return default
 
 
-class LooseFileLike(BytesIO):
-    def close(self):
-        value = self.getvalue()
-        super().close()
-        self.getvalue = lambda: value
-
-
 class MockSession(BenchmarkSession):
     def __init__(self, name_format):
         self.histogram = True
@@ -396,14 +389,15 @@ def test_compare_2(sess, LineMatcher):
 
 @freeze_time('2015-08-15T00:04:18.687119')
 def test_save_json(sess, tmpdir, monkeypatch):
+    json_path = Path(str(tmpdir)) / 'output.json'
     monkeypatch.setattr(plugin, '__version__', '2.5.0')
     sess.save = False
     sess.autosave = False
-    sess.json = LooseFileLike()
+    sess.json = json_path
     sess.save_data = False
     sess.handle_saving()
-    assert tmpdir.listdir() == []
-    assert json.loads(sess.json.getvalue().decode()) == JSON_DATA
+    assert json_path.exists()
+    assert json.loads(json_path.read_text(encoding='utf8')) == JSON_DATA
 
 
 @freeze_time('2015-08-15T00:04:18.687119')


### PR DESCRIPTION

`argparse.FileType` is [deprecated in python 3.14+](https://docs.python.org/3/library/argparse.html#argparse.FileType).

Before this change, a deprecation warning about "FileType is deprecated" would be emitted:
```
$ PYTHONWARNINGS=all pytest -h                    
/home/sophia/miniconda3/envs/pytest-benchmark-dev/bin/pytest:10: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguous
and fails to parse leap day. The default behavior will change in Python 3.15
to either always raise an exception or to use a different default year (TBD).
To avoid trouble, add a specific year to the input & format.
See https://github.com/python/cpython/issues/70647.
  sys.exit(console_main())
/home/sophia/projects/pytest-benchmark/src/pytest_benchmark/plugin.py:260: PendingDeprecationWarning: FileType is deprecated. Simply open files after parsing arguments.
  type=argparse.FileType('wb'),
usage: pytest [options] [file_or_dir] [file_or_dir] [...]
```

With this change:
```
$ PYTHONWARNINGS=all pytest -h                    
/home/sophia/miniconda3/envs/pytest-benchmark-dev/bin/pytest:10: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguous
and fails to parse leap day. The default behavior will change in Python 3.15
to either always raise an exception or to use a different default year (TBD).
To avoid trouble, add a specific year to the input & format.
See https://github.com/python/cpython/issues/70647.
  sys.exit(console_main())
usage: pytest [options] [file_or_dir] [file_or_dir] [...]
```

Fixes https://github.com/ionelmc/pytest-benchmark/issues/283