### PR TITLE
Don't let internal warnings become errors under filterwarnings=error

### DIFF
--- a/src/pytest_benchmark/logger.py
+++ b/src/pytest_benchmark/logger.py
@@ -40,8 +40,20 @@ class Logger:
             if suspend and self.resume_capture:
                 self.resume_capture()
         if warner is None:
-            warner = warnings.warn
-        warner(PytestBenchmarkWarning(text))
+            # These are informational messages about the plugin's own behavior (e.g. benchmarks
+            # being auto-disabled), not warnings about the user's code, so they shouldn't be
+            # promotable to errors by the user's `filterwarnings` setting. Doing so would abort
+            # the whole session with an INTERNALERROR very early (during pytest_configure).
+            # We can't use `warnings.catch_warnings()` here as it would also reset pytest's own
+            # warnings-capturing state (breaking `-W`/`--benchmark-verbose` and the warnings
+            # summary), so we push/pop a single filter entry instead.
+            warnings.filterwarnings('always', category=PytestBenchmarkWarning)
+            try:
+                warnings.warn(PytestBenchmarkWarning(text), stacklevel=2)
+            finally:
+                warnings.filters.pop(0)
+        else:
+            warner(PytestBenchmarkWarning(text))
 
     def error(self, text):
         self.term.line('')

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -924,6 +924,23 @@ def test_xdist_verbose(testdir):
     )
 
 
+def test_xdist_filterwarnings_error(testdir):
+    # Regression test for https://github.com/ionelmc/pytest-benchmark/issues/286
+    # With `filterwarnings = error`, the plugin's own xdist-disabled notice must not be
+    # promoted to an exception (which used to blow up pytest_configure with an INTERNALERROR).
+    pytest.importorskip('xdist')
+    testdir.makeini(
+        """
+        [pytest]
+        filterwarnings = error
+        """
+    )
+    test = testdir.makepyfile(SIMPLE_TEST)
+    result = testdir.runpytest_subprocess('-n', '1', test)
+    assert 'INTERNALERROR' not in result.stderr.str()
+    result.stdout.fnmatch_lines(['*2 passed*'])
+
+
 def test_cprofile(testdir):
     test = testdir.makepyfile(SIMPLE_TEST)
     result = testdir.runpytest_subprocess('--benchmark-cprofile=cumtime', test)


### PR DESCRIPTION
Fixes #286.

`BenchmarkSession` emits informational notices (e.g. "Benchmarks are automatically disabled because xdist plugin is active") via plain `warnings.warn()`. When a project sets `filterwarnings = error`, that promotes the notice to an exception during `pytest_configure`, so the whole session dies with an `INTERNALERROR` before any test runs.

These messages describe the plugin's own behavior rather than anything about the user's code, so they shouldn't be subject to the user's `filterwarnings` policy. The fix scopes an "always" filter just around the `warn()` call for the plain-`warnings.warn` path (the `request.node.warn` path used for the "benchmark fixture was not used" warning is untouched, since that one is legitimately about the user's test).

I avoided `warnings.catch_warnings()` for this since it also resets pytest's own warning-capture state and broke the existing `-rw`/`--benchmark-verbose` xdist tests; a single filter push/pop avoids that.

Added a regression test (`test_xdist_filterwarnings_error`) reproducing the exact crash from the issue and asserting it no longer happens.