### PR TITLE
Defer xdist warning until benchmark collection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,3 +44,4 @@ Authors
 * Thomas B. Brunner - https://github.com/thomasbbrunner
 * Hugo van Kemenade - https://github.com/hugovk
 * Aarni Koskela - https://github.com/akx
+* xlyyddy - https://github.com/xlyyddy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Defer the xdist auto-disable warning until a benchmark fixture is collected.
+  Contributed by xlyyddy for `#65 <https://github.com/ionelmc/pytest-benchmark/issues/65>`_.
+
 v5.2.3 (2025-11-09)
 --------------------
 

--- a/src/pytest_benchmark/plugin.py
+++ b/src/pytest_benchmark/plugin.py
@@ -340,6 +340,7 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         has_benchmark = hasattr(item, 'fixturenames') and 'benchmark' in item.fixturenames
         if has_benchmark:
+            bs.note_xdist_benchmark()
             if bs.skip:
                 item.add_marker(skip_bench)
         else:

--- a/src/pytest_benchmark/session.py
+++ b/src/pytest_benchmark/session.py
@@ -71,14 +71,11 @@ class BenchmarkSession:
         self.disabled = config.getoption('benchmark_disable') and not config.getoption('benchmark_enable')
 
         # Only the main process has the 'dist' field in the config.
-        xdist_worker = os.environ.get('PYTEST_XDIST_WORKER')
-        xdist_active = config.getoption('dist', 'no') != 'no' or xdist_worker
-        if xdist_active and not self.skip and not self.disabled:
-            if not xdist_worker:
-                self.logger.warning(
-                    'Benchmarks are automatically disabled because xdist plugin is active. '
-                    'Benchmarks cannot be performed reliably in a parallelized environment.',
-                )
+        self.xdist_worker = os.environ.get('PYTEST_XDIST_WORKER')
+        xdist_active = config.getoption('dist', 'no') != 'no' or self.xdist_worker
+        self.xdist_warning = bool(xdist_active and not self.skip and not self.disabled)
+        self.xdist_benchmark_found = False
+        if self.xdist_warning:
             self.disabled = True
         if hasattr(config, 'slaveinput'):
             self.disabled = True
@@ -107,6 +104,18 @@ class BenchmarkSession:
         self.compare_fail = config.getoption('benchmark_compare_fail')
         self.name_format = NAME_FORMATTERS[config.getoption('benchmark_name')]
         self.histogram = first_or_value(config.getoption('benchmark_histogram'), False)
+
+    def note_xdist_benchmark(self):
+        if self.xdist_warning and self.xdist_worker in (None, 'gw0'):
+            self.xdist_benchmark_found = True
+
+    def pytest_unconfigure(self):
+        # Worker collection captures warnings into pytest's summary, so defer to preserve Logger's stderr output.
+        if self.xdist_benchmark_found:
+            self.logger.warning(
+                'Benchmarks are automatically disabled because xdist plugin is active. '
+                'Benchmarks cannot be performed reliably in a parallelized environment.',
+            )
 
     def get_machine_info(self):
         obj = self.config.hook.pytest_benchmark_generate_machine_info(config=self.config)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -898,30 +898,61 @@ def test_bogus_sort(testdir):
     )
 
 
+XDIST_WARNING = (
+    'Benchmarks are automatically disabled because xdist plugin is active. '
+    'Benchmarks cannot be performed reliably in a parallelized environment.'
+)
+
+
 def test_xdist(testdir):
     pytest.importorskip('xdist')
     test = testdir.makepyfile(SIMPLE_TEST)
-    result = testdir.runpytest_subprocess('--doctest-modules', '-n', '1', '-rw', test)
-    result.stderr.fnmatch_lines(
-        [
-            '* Benchmarks are automatically disabled because xdist plugin is active. Benchmarks cannot be '
-            'performed reliably in a parallelized environment.',
-        ]
-    )
+    result = testdir.runpytest_subprocess('--doctest-modules', '-n', '2', '-rw', test)
+    result.stderr.fnmatch_lines([f'* {XDIST_WARNING}'])
+    assert result.stderr.str().count(f'PytestBenchmarkWarning: {XDIST_WARNING}') == 1
 
 
 def test_xdist_verbose(testdir):
     pytest.importorskip('xdist')
     test = testdir.makepyfile(SIMPLE_TEST)
     result = testdir.runpytest_subprocess('--doctest-modules', '-n', '1', '--benchmark-verbose', test)
-    result.stderr.fnmatch_lines(
-        [
-            '------*',
-            ' WARNING: Benchmarks are automatically disabled because xdist plugin is active. Benchmarks cannot be performed '
-            'reliably in a parallelized environment.',
-            '------*',
-        ]
+    result.stderr.fnmatch_lines(['------*', f' WARNING: {XDIST_WARNING}', '------*'])
+    assert result.stderr.str().count(f' WARNING: {XDIST_WARNING}') == 1
+
+
+def test_xdist_without_benchmark(testdir):
+    pytest.importorskip('xdist')
+    test = testdir.makepyfile(
+        """
+def test_regular():
+    pass
+"""
     )
+    result = testdir.runpytest_subprocess('-n', '1', test)
+    result.assert_outcomes(passed=1)
+    assert XDIST_WARNING not in result.stderr.str()
+    assert XDIST_WARNING not in result.stdout.str()
+
+
+@pytest.mark.parametrize(
+    ('option', 'outcomes'),
+    [
+        ('--benchmark-disable', {'passed': 1}),
+        ('--benchmark-skip', {'skipped': 1}),
+    ],
+)
+def test_xdist_explicit_benchmark_option_does_not_warn(testdir, option, outcomes):
+    pytest.importorskip('xdist')
+    test = testdir.makepyfile(
+        """
+def test_bench(benchmark):
+    benchmark(lambda: None)
+"""
+    )
+    result = testdir.runpytest_subprocess('-n', '1', option, test)
+    result.assert_outcomes(**outcomes)
+    assert XDIST_WARNING not in result.stderr.str()
+    assert XDIST_WARNING not in result.stdout.str()
 
 
 def test_cprofile(testdir):


### PR DESCRIPTION
Closes #65.

## Summary

- Defer the xdist auto-disable warning until collection proves that a test uses the `benchmark` fixture.
- Emit the warning once from `gw0`, because the xdist controller does not collect test items.
- Preserve the existing normal and verbose stderr output while avoiding warnings for suites without benchmarks.
- Keep explicit `--benchmark-disable` and `--benchmark-skip` runs quiet.

## Test plan

- xdist-focused tests with pytest 8.4.2 and 9.0.2
- `tests/test_benchmark.py` (56 passed)
- tests without xdist loaded (14 passed)
- CLI-related tests (21 passed)
- Ruff check and format check

I also ran the repository `check` tox environment. The sdist build, Twine check, manifest check, Ruff, formatting, Mypy, spelling, and generic file hooks passed. The local Taplo lint step could not decode the remote schema catalog response; this change does not modify TOML files.
